### PR TITLE
`CMakePresets.json`: Use the `MJX` prefix for common cache variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,18 +6,18 @@
 cmake_minimum_required(VERSION 3.21.0)
 project(mjmem_library LANGUAGES CXX)
 
-# check if the MJMEM_PLATFORM_ARCH variable is not defined, if it's undefined,
+# check if the MJX_PLATFORM_ARCH variable is not defined, if it's undefined,
 # set its value based on the CMAKE_GENERATOR_PLATFORM predefined variable
-if(NOT DEFINED MJMEM_PLATFORM_ARCH)
+if(NOT DEFINED MJX_PLATFORM_ARCH)
     if(CMAKE_GENERATOR_PLATFORM STREQUAL "x64")
-        set(MJMEM_PLATFORM_ARCH "x64")
+        set(MJX_PLATFORM_ARCH "x64")
     elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "Win32")
-        set(MJMEM_PLATFORM_ARCH "x86") # translate Win32 into x86
+        set(MJX_PLATFORM_ARCH "x86") # translate Win32 into x86
     endif()
 endif()
 
 # check if the platform architecture is supported
-if(NOT ${MJMEM_PLATFORM_ARCH} MATCHES "^x64$|^x86$")
+if(NOT ${MJX_PLATFORM_ARCH} MATCHES "^x64$|^x86$")
     message(FATAL_ERROR "The MJMEM library can only be built for x64 and x86 architectures.")
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,7 +21,7 @@
                 "value": "x64"
             },
             "cacheVariables": {
-                "MJMEM_PLATFORM_ARCH": "x64"
+                "MJX_PLATFORM_ARCH": "x64"
             }
         },
         {
@@ -33,7 +33,7 @@
                 "value": "Win32"
             },
             "cacheVariables": {
-                "MJMEM_PLATFORM_ARCH": "x86"
+                "MJX_PLATFORM_ARCH": "x86"
             }
         }
     ],

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The MJMEM library is a memory management toolset designed as a module for future
 
 - [Changelog][] tracks all changes made in each release.
 - [License][] defines the legal rights regarding the use of this library.
+- [Documentation][] describes all functions and classes included in this library.
 
 # Build steps
 
@@ -105,6 +106,7 @@ SPDX-License-Identifier: Apache-2.0
 [status-badge-link]: https://github.com/MateuszJanduraUszu/mjmem/actions/workflows/build-and-test.yml
 [Changelog]: CHANGELOG.md
 [License]: LICENSE
+[Documentation]: docs/README.md
 [CMake]: https://cmake.org/download
 [issues]: https://github.com/MateuszJanduraUszu/mjmem/issues
 [email]: mailto:mjandura03@gmail.com


### PR DESCRIPTION
Resolves #28, additionally mentions about the documentation in the main `README.md`