### PR TITLE
`<exception>`: Restore `pool_exhausted` for backward compatibility

### DIFF
--- a/src/mjmem/exception.cpp
+++ b/src/mjmem/exception.cpp
@@ -22,6 +22,16 @@ namespace mjx {
         throw allocation_limit_exceeded();
     }
 
+#if !_MJMEM_VERSION_SUPPORTED(1, 0, 1)
+    pool_exhausted::pool_exhausted() noexcept {}
+
+    pool_exhausted::~pool_exhausted() noexcept {}
+
+    void pool_exhausted::raise() {
+        throw pool_exhausted();
+    }
+#endif // !_MJMEM_VERSION_SUPPORTED(1, 0, 1)
+
     resource_overrun::resource_overrun() noexcept {}
 
     resource_overrun::~resource_overrun() noexcept {}

--- a/src/mjmem/exception.hpp
+++ b/src/mjmem/exception.hpp
@@ -7,6 +7,7 @@
 #ifndef _MJMEM_EXCEPTION_HPP_
 #define _MJMEM_EXCEPTION_HPP_
 #include <mjmem/api.hpp>
+#include <mjmem/version.hpp>
 
 namespace mjx {
     class _MJMEM_API allocation_failure {
@@ -26,6 +27,17 @@ namespace mjx {
         // raises allocation limit exceeded exception
         [[noreturn]] static void raise();
     };
+
+#if !_MJMEM_VERSION_SUPPORTED(1, 0, 1)
+    class _MJMEM_API pool_exhausted {
+    public:
+        pool_exhausted() noexcept;
+        ~pool_exhausted() noexcept;
+
+        // raises pool exhausted exception
+        [[noreturn]] static void raise();
+    };
+#endif // !_MJMEM_VERSION_SUPPORTED(1, 0, 1)
 
     class _MJMEM_API resource_overrun {
     public:

--- a/src/mjmem/pool_allocator.cpp
+++ b/src/mjmem/pool_allocator.cpp
@@ -14,8 +14,7 @@ namespace mjx {
         : _Myres(_Resource), _Mymax((::std::min)(_Max_block_size, _Resource.size())), _Mylist() {
 #ifdef _DEBUG
         if (_Mymax != unbounded_block_size) { // maximum block size specified, validate it
-            _INTERNAL_ASSERT(
-                _Myres.size() >= _Mymax, "maximum block size cannot exceed the total pool resource size")
+            _INTERNAL_ASSERT(_Myres.size() >= _Mymax, "maximum block size cannot exceed the total pool resource size");
         }
 #endif // _DEBUG
 
@@ -168,7 +167,11 @@ namespace mjx {
     pool_allocator::pointer pool_allocator::allocate(const size_type _Count) {
         pointer _Ptr = _Allocate(_Count);
         if (!_Ptr) { // not enough memory, raise an exception
+#if _MJMEM_VERSION_SUPPORTED(1, 0, 1)
             allocation_failure::raise();
+#else // ^^^ _MJMEM_VERSION_SUPPORTED(1, 0, 1) ^^^ / vvv !_MJMEM_VERSION_SUPPORTED(1, 0, 1) vvv
+            pool_exhausted::raise();
+#endif // _MJMEM_VERSION_SUPPORTED(1, 0, 1)
         }
 
         return _Ptr;


### PR DESCRIPTION
Resolves #25