### PR TITLE
`<smart_pointer>`: Remove `operator*()` and `operator->()` from `unique_smart_array` and `smart_array`

### DIFF
--- a/docs/reference/smart_pointer/smart_array-operator-arrow.md
+++ b/docs/reference/smart_pointer/smart_array-operator-arrow.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+> **Important**: This function has been deprecated and removed from the library since version 2.0.0.
+
 Retrieves the stored array.
 
 ## Syntax
@@ -33,7 +35,7 @@ object because the class stores an array, not a pointer to an object. The operat
 |-------------------------|-----------------------|
 | Include header          | `<smart_pointer.hpp>` |
 | Minimum library version | `1.0.1`               |
-| Maximum library version | `N/A`                 |
+| Maximum library version | `1.0.2`               |
 
 ## See also
 

--- a/docs/reference/smart_pointer/smart_array-operator-deref.md
+++ b/docs/reference/smart_pointer/smart_array-operator-deref.md
@@ -26,7 +26,9 @@ Returns a read-only reference to the first element of the stored array.
 
 ## Remarks
 
-The function returns the first element of the stored array. The behavior is undefined if the stored array is null. It is equivalent to:
+The function returns the first element of the stored array. The behavior is undefined if the stored array is null. Unlike 
+[smart_ptr::operator*](smart_ptr-operator-deref.md), this function does not dereference the pointer because the class stores an array, not 
+a pointer to an object. The operator is defined for consistency with smart pointers. It is equivalent to:
 
 ```cpp
 *get();

--- a/docs/reference/smart_pointer/smart_array-operator-deref.md
+++ b/docs/reference/smart_pointer/smart_array-operator-deref.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+> **Important**: This function has been deprecated and removed from the library since version 2.0.0.
+
 Retrieves the first element of the stored array.
 
 ## Syntax
@@ -36,7 +38,7 @@ The function returns the first element of the stored array. The behavior is unde
 |-------------------------|-----------------------|
 | Include header          | `<smart_pointer.hpp>` |
 | Minimum library version | `1.0.1`               |
-| Maximum library version | `N/A`                 |
+| Maximum library version | `1.0.2`               |
 
 ## See also
 

--- a/docs/reference/smart_pointer/smart_array.md
+++ b/docs/reference/smart_pointer/smart_array.md
@@ -26,8 +26,11 @@ public:
     smart_array& operator=(smart_array&& _Other) noexcept;
     smart_array& operator=(unique_smart_array<_Ty>&& _Sarr);
 
+#if !_MJMEM_VERSION_SUPPORTED(2, 0, 0)
     explicit operator bool() const noexcept;
     element_type& operator*() const noexcept;
+#endif // !_MJMEM_VERSION_SUPPORTED(2, 0, 0)
+
     pointer operator->() const noexcept;
     element_type& operator[](const size_t _Idx) const;
     pointer get() const noexcept;

--- a/docs/reference/smart_pointer/unique_smart_array-operator-arrow.md
+++ b/docs/reference/smart_pointer/unique_smart_array-operator-arrow.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+> **Important**: This function has been deprecated and removed from the library since version 2.0.0.
+
 Retrieves the stored array.
 
 ## Syntax
@@ -34,7 +36,7 @@ pointers.
 |-------------------------|-----------------------|
 | Include header          | `<smart_pointer.hpp>` |
 | Minimum library version | `1.0.1`               |
-| Maximum library version | `N/A`                 |
+| Maximum library version | `1.0.2`               |
 
 ## See also
 

--- a/docs/reference/smart_pointer/unique_smart_array-operator-deref.md
+++ b/docs/reference/smart_pointer/unique_smart_array-operator-deref.md
@@ -26,7 +26,9 @@ Returns a read-only reference to the first element of the stored array.
 
 ## Remarks
 
-The function returns the first element of the stored array. The behavior is undefined if the stored array is null. It is equivalent to:
+The function returns the first element of the stored array. The behavior is undefined if the stored array is null. Unlike 
+[unique_smart_ptr::operator*](unique_smart_ptr-operator-deref.md), this function does not dereference the pointer because the class 
+stores an array, not a pointer to an object. The operator is defined for consistency with smart pointers. It is equivalent to:
 
 ```cpp
 *get();

--- a/docs/reference/smart_pointer/unique_smart_array-operator-deref.md
+++ b/docs/reference/smart_pointer/unique_smart_array-operator-deref.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+> **Important**: This function has been deprecated and removed from the library since version 2.0.0.
+
 Retrieves the first element of the stored array.
 
 ## Syntax
@@ -36,7 +38,7 @@ The function returns the first element of the stored array. The behavior is unde
 |-------------------------|-----------------------|
 | Include header          | `<smart_pointer.hpp>` |
 | Minimum library version | `1.0.1`               |
-| Maximum library version | `N/A`                 |
+| Maximum library version | `1.0.2`               |
 
 ## See also
 

--- a/docs/reference/smart_pointer/unique_smart_array.md
+++ b/docs/reference/smart_pointer/unique_smart_array.md
@@ -31,8 +31,11 @@ public:
     unique_smart_array(const unique_smart_array&)            = delete;
     unique_smart_array& operator=(const unique_smart_array&) = delete;
 
+#if !_MJMEM_VERSION_SUPPORTED(2, 0, 0)
     element_type& operator*() const noexcept;
     pointer operator->() const noexcept;
+#endif // !_MJMEM_VERSION_SUPPORTED(2, 0, 0)
+
     element_type& operator[](const size_t _Idx) const;
     explicit operator bool() const noexcept;
     pointer get() const noexcept;

--- a/src/mjmem/smart_pointer.hpp
+++ b/src/mjmem/smart_pointer.hpp
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <mjmem/exception.hpp>
 #include <mjmem/object_allocator.hpp>
+#include <mjmem/version.hpp>
 #include <type_traits>
 #include <utility>
 
@@ -293,6 +294,7 @@ namespace mjx {
         unique_smart_array(const unique_smart_array&)            = delete;
         unique_smart_array& operator=(const unique_smart_array&) = delete;
 
+#if !_MJMEM_VERSION_SUPPORTED(2, 0, 0)
         element_type& operator*() const noexcept {
             return *_Myptr;
         }
@@ -300,6 +302,7 @@ namespace mjx {
         pointer operator->() const noexcept {
             return _Myptr;
         }
+#endif // !_MJMEM_VERSION_SUPPORTED(2, 0, 0)
 
         element_type& operator[](const size_t _Idx) const {
             if (_Idx >= _Mysize) {
@@ -569,6 +572,7 @@ namespace mjx {
             return _Myptr != nullptr;
         }
 
+#if !_MJMEM_VERSION_SUPPORTED(2, 0, 0)
         element_type& operator*() const noexcept {
             // the behavior is undefined if the stored pointer is null
             return *_Myptr;
@@ -577,6 +581,7 @@ namespace mjx {
         pointer operator->() const noexcept {
             return _Myptr;
         }
+#endif // !_MJMEM_VERSION_SUPPORTED(2, 0, 0)
 
         element_type& operator[](const size_t _Idx) const {
             if (_Idx >= _Mysize) {


### PR DESCRIPTION
Resolves #41