### PR TITLE
`<pool_allocator>`: Optimize `pool_allocator`'s internal list of free blocks

### DIFF
--- a/docs/reference/block_allocator/block_allocator.md
+++ b/docs/reference/block_allocator/block_allocator.md
@@ -7,7 +7,7 @@ Defines a stateful fixed-size block allocator associated with a [resource](../po
 ## Syntax
 
 ```cpp
-class block_allocator {
+class block_allocator : public allocator {
 public:
     using value_type      = allocator::value_type;
     using size_type       = allocator::size_type;
@@ -26,8 +26,11 @@ public:
     void deallocate(pointer _Ptr, const size_type _Count) noexcept override;
     size_type max_size() const noexcept override;
     bool is_equal(const allocator& _Other) const noexcept override;
+
+#if _MJMEM_VERSION_SUPPORTED(2, 0, 0)
     size_type block_size() const noexcept;
     const pool_resource& resource() const noexcept;
+#endif // _MJMEM_VERSION_SUPPORTED(2, 0, 0)
 };
 ```
 

--- a/docs/reference/dynamic_allocator/dynamic_allocator.md
+++ b/docs/reference/dynamic_allocator/dynamic_allocator.md
@@ -7,7 +7,7 @@ Defines a stateless allocator that relies on memory management provided by the o
 ## Syntax
 
 ```cpp
-class dynamic_allocator {
+class dynamic_allocator : public allocator {
 public:
     using value_type      = allocator::value_type;
     using size_type       = allocator::size_type;

--- a/docs/reference/pool_allocator/pool_allocator-allocate.md
+++ b/docs/reference/pool_allocator/pool_allocator-allocate.md
@@ -25,9 +25,9 @@ Returns a pointer to the allocated memory block if successful; otherwise, return
 
 ## Remarks
 
-When the function is called, it searches the list of free blocks for one that is at least the requested number of bytes. Since the list is 
-sorted, the smallest suitable block is selected. If the selected block is the same size as the requested number of bytes, the node is 
-deleted from the list. Otherwise, the node's offset and size are updated to reflect the allocation.
+When the function is called, it searches the list of free blocks for one that is at least the requested number of bytes. If the selected block 
+is the same size as the requested number of bytes, the node is deleted from the list. Otherwise, the node's offset and size are updated to 
+reflect the allocation.
 
 ## Requirements
 

--- a/docs/reference/pool_allocator/pool_allocator-ctor.md
+++ b/docs/reference/pool_allocator/pool_allocator-ctor.md
@@ -25,7 +25,7 @@ Throws [allocation_failure](../exception/allocation_failure.md) if the allocatio
 
 ## Remarks
 
-Since the allocator is stateful, it must be initialized first. During initialization, a sorted doubly-linked list of free blocks is created. Initially, 
+Since the allocator is stateful, it must be initialized first. During initialization, a sorted singly-linked list of free blocks is created. Initially, 
 the list contains only one free block, which represents the entire memory block from the associated resource.
 
 ## Requirements

--- a/docs/reference/pool_allocator/pool_allocator.md
+++ b/docs/reference/pool_allocator/pool_allocator.md
@@ -7,7 +7,7 @@ Defines a variable-size block allocator associated with a [resource](../pool_res
 ## Syntax
 
 ```cpp
-class pool_allocator {
+class pool_allocator : public allocator {
 public:
     using value_type      = allocator::value_type;
     using size_type       = allocator::size_type;
@@ -28,7 +28,10 @@ public:
     void deallocate(pointer _Ptr, const size_type _Count) noexcept override;
     size_type max_size() const noexcept override;
     bool is_equal(const allocator& _Other) const noexcept override;
+
+#if _MJMEM_VERSION_SUPPORTED(2, 0, 0)
     const pool_resource& resource() const noexcept;
+#endif // _MJMEM_VERSION_SUPPORTED(2, 0, 0)
 };
 ```
 
@@ -66,7 +69,7 @@ public:
 ## Remarks
 
 The allocator operates on a user-provided preallocated memory block stored in the associated resource. It employs a sorted 
-doubly-linked list of free blocks to store information about available blocks.
+singly-linked list of free blocks to store information about available blocks.
 
 ## Requirements
 

--- a/docs/reference/synchronized_allocator/synchronized_allocator.md
+++ b/docs/reference/synchronized_allocator/synchronized_allocator.md
@@ -7,7 +7,7 @@ Defines an allocator that manages access to the associated allocator in a multit
 ## Syntax
 
 ```cpp
-class synchronized_allocator {
+class synchronized_allocator : public allocator {
 public:
     using value_type      = allocator::value_type;
     using size_type       = allocator::size_type;

--- a/src/mjmem/pool_allocator.cpp
+++ b/src/mjmem/pool_allocator.cpp
@@ -92,7 +92,7 @@ namespace mjx {
     }
 
     void pool_allocator::_Free_block_list::_Insert_node(_List_node* const _New_node) noexcept {
-        if (!_Myhead || _Myhead->_Off >= _New_node->_Off) { // insert before the head
+        if (!_Myhead || _Myhead->_Off > _New_node->_Off) { // insert before the head
             _New_node->_Next = _Myhead;
             _Myhead          = _New_node;
             return;

--- a/src/mjmem/pool_allocator.cpp
+++ b/src/mjmem/pool_allocator.cpp
@@ -3,9 +3,11 @@
 // Copyright (c) Mateusz Jandura. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdlib>
 #include <mjmem/dynamic_allocator.hpp>
 #include <mjmem/exception.hpp>
 #include <mjmem/impl/utils.hpp>
+#include <mjmem/object_allocator.hpp>
 #include <mjmem/pool_allocator.hpp>
 #include <utility>
 
@@ -14,7 +16,8 @@ namespace mjx {
         : _Myres(_Resource), _Mymax((::std::min)(_Max_block_size, _Resource.size())), _Mylist() {
 #ifdef _DEBUG
         if (_Mymax != unbounded_block_size) { // maximum block size specified, validate it
-            _INTERNAL_ASSERT(_Myres.size() >= _Mymax, "maximum block size cannot exceed the total pool resource size");
+            _INTERNAL_ASSERT(
+                _Myres.size() >= _Mymax, "maximum block size cannot exceed the total pool resource size");
         }
 #endif // _DEBUG
 
@@ -23,90 +26,124 @@ namespace mjx {
 
     pool_allocator::~pool_allocator() noexcept {}
 
-    pool_allocator::_List::_List() noexcept : _Myhead(nullptr), _Mytail(nullptr), _Mysize(0) {}
+    pool_allocator::_Free_block_list::_Free_block_list() noexcept : _Myhead(nullptr), _Mysize(0) {}
 
-    pool_allocator::_List::~_List() noexcept {
+    pool_allocator::_Free_block_list::~_Free_block_list() noexcept {
         if (_Myhead) { // deallocate all nodes
             dynamic_allocator _Al;
             for (_List_node* _Node = _Myhead, *_Next; _Node != nullptr; _Node = _Next) {
                 _Next = _Node->_Next;
-                _Node->~_List_node();
-                _Al.deallocate(_Node, sizeof(_List));
+                ::mjx::delete_object_using_allocator(_Node, _Al);
             }
 
             _Myhead = nullptr;
-            _Mytail = nullptr;
             _Mysize = 0;
         }
     }
 
-    pool_allocator::_List_node* pool_allocator::_List::_Create_node() {
+    pool_allocator::_Free_block_list::_List_node* pool_allocator::_Free_block_list::_List_node::_Create() {
         dynamic_allocator _Al;
-        return ::new (_Al.allocate(sizeof(_List_node))) _List_node;
+        return ::mjx::create_object_using_allocator<_List_node>(_Al);
     }
     
-    void pool_allocator::_List::_Deallocate_node(_List_node* const _Node) noexcept {
+    void pool_allocator::_Free_block_list::_List_node::_Delete(_List_node* const _Node) noexcept {
         dynamic_allocator _Al;
-        _Node->~_List_node();
-        _Al.deallocate(_Node, sizeof(_List_node));
+        ::mjx::delete_object_using_allocator(_Node, _Al);
     }
 
-    void pool_allocator::_List::_Unlink_node(_List_node* const _Node) noexcept {
-        if (_Node->_Prev) { // break connection with the previous node
-            _Node->_Prev->_Next = _Node->_Next;
+    void pool_allocator::_Free_block_list::_Unlink_node_directly(
+        _List_node* const _Prev, _List_node* const _Node) noexcept {
+        if (_Prev) { // break connection with the previous node
+            _Prev->_Next = _Node->_Next;
         } else { // set a new head
             _Myhead = _Node->_Next;
         }
+    }
 
-        if (_Node->_Next) { // break connection with the next node
-            _Node->_Next->_Prev = _Node->_Prev;
-        } else { // set a new tail
-            _Mytail = _Node->_Prev;
+    void pool_allocator::_Free_block_list::_Unlink_node_indirectly(_List_node* const _Node) noexcept {
+        if (_Node == _Myhead) { // set a new head
+            _Myhead = _Myhead->_Next;
+            return;
+        }
+
+        _List_node* _Prev    = nullptr;
+        _List_node* _Current = _Myhead;
+        while (_Current && _Current != _Node) { // search for _Node's parent
+            _Prev    = _Current;
+            _Current = _Current->_Next;
+        }
+
+        if (_Current == _Node) { // _Node's parent found, unlink _Node
+            _Unlink_node_directly(_Prev, _Node);
         }
     }
 
-    void pool_allocator::_List::_Delete_node(_List_node* const _Node) noexcept {
-        _Unlink_node(_Node);
-        _Deallocate_node(_Node);
+    void pool_allocator::_Free_block_list::_Delete_node_directly(
+        _List_node* const _Prev, _List_node* const _Node) noexcept {
+        _Unlink_node_directly(_Prev, _Node);
+        _List_node::_Delete(_Node);
         --_Mysize;
     }
 
-    void pool_allocator::_List::_Insert_node(_List_node* const _New_node) noexcept {
+    void pool_allocator::_Free_block_list::_Delete_node_indirectly(_List_node* const _Node) noexcept {
+        _Unlink_node_indirectly(_Node);
+        _List_node::_Delete(_Node);
+        --_Mysize;
+    }
+
+    void pool_allocator::_Free_block_list::_Insert_node(_List_node* const _New_node) noexcept {
+        if (!_Myhead || _Myhead->_Off >= _New_node->_Off) { // insert before the head
+            _New_node->_Next = _Myhead;
+            _Myhead          = _New_node;
+            return;
+        }
+
         _List_node* _Node = _Myhead;
-        while (_Node && _Node->_Size > _New_node->_Size) { // search for smaller block to insert before it
+        while (_Node->_Next && _Node->_Next->_Off < _New_node->_Off) {
+            // search for the next block to insert before it
             _Node = _Node->_Next;
         }
 
-        if (_Node) { // insert before the tail
-            _New_node->_Next = _Node;
-            _New_node->_Prev = _Node->_Prev;
-            if (_Node->_Prev) { // insert after the head
-                _Node->_Prev->_Next = _New_node;
-            } else { // insert before the head
-                _Myhead = _New_node;
+        _New_node->_Next = _Node->_Next;
+        _Node->_Next     = _New_node;
+    }
+
+    bool pool_allocator::_Free_block_list::_Merge_contiguous_block_before(
+        _List_node* const _Prev, _List_node* const _Node, const size_type _Off, const size_type _Size) noexcept {
+        if (_Off + _Size == _Node->_Off) { // merge the block with _Node
+            _Node->_Off  -= _Size;
+            _Node->_Size += _Size;
+            if (_Prev && _Prev->_Off + _Prev->_Size == _Node->_Off) { // merge _Prev with _Node
+                _Node->_Off  -= _Prev->_Size;
+                _Node->_Size += _Prev->_Size;
+                _Delete_node_indirectly(_Prev);
             }
 
-            _Node->_Prev = _New_node;
-        } else { // insert after the tail
-            _New_node->_Prev = _Mytail;
-            _Mytail->_Next   = _New_node;
-            _Mytail          = _New_node;
+            return true;
         }
+
+        return false;
     }
 
-    void pool_allocator::_List::_Reinsert_node(_List_node* const _Node) noexcept {
-        _Unlink_node(_Node);
-        _Insert_node(_Node);
+    bool pool_allocator::_Free_block_list::_Merge_contiguous_block_after(
+        _List_node* const _Node, const size_type _Off, const size_type _Size) noexcept {
+        if (_Node->_Off + _Node->_Size == _Off) { // merge block with _Node
+            _Node->_Size += _Size;
+            if (_Node->_Next && _Node->_Off + _Node->_Size == _Node->_Next->_Off) { // merge _Node with _Node->_Next
+                _Node->_Size += _Node->_Next->_Size;
+                _Delete_node_directly(_Node, _Node->_Next);
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
-    bool pool_allocator::_List::_Merge_block(const size_type _Off, const size_type _Size) noexcept {
-        for (_List_node* _Node = _Myhead; _Node != nullptr; _Node = _Node->_Next) {
-            if (_Node->_Off + _Node->_Size == _Off) { // found appropriate block, merge with it
-                _Node->_Size += _Size;
-                if (_Node->_Prev && _Node->_Prev->_Size < _Node->_Size) { // re-insert node to keep list sorted
-                    _Reinsert_node(_Node);
-                }
-
+    bool pool_allocator::_Free_block_list::_Merge_block(const size_type _Off, const size_type _Size) noexcept {
+        for (_List_node* _Node = _Myhead, *_Prev = nullptr; _Node != nullptr; _Prev = _Node, _Node = _Node->_Next) {
+            if (_Merge_contiguous_block_before(_Prev, _Node, _Off, _Size)
+                || _Merge_contiguous_block_after(_Node, _Off, _Size)) { // block merged, break
                 return true;
             }
         }
@@ -114,41 +151,74 @@ namespace mjx {
         return false;
     }
 
-    pool_allocator::size_type pool_allocator::_List::_Size() const noexcept {
+    void pool_allocator::_Free_block_list::_Release_block_zero(const size_type _Size) {
+        if (_Myhead && _Myhead->_Off == _Size) { // merge block to the head
+            _Myhead->_Off   = 0;
+            _Myhead->_Size += _Size;
+            return;
+        }
+
+        _List_node* const _New_node = _List_node::_Create();
+        _New_node->_Off             = 0;
+        _New_node->_Size            = _Size;
+        if (_Myhead) { // insert before the head
+            _New_node->_Next = _Myhead;
+            _Myhead          = _New_node;
+        } else { // set a new head
+            _Myhead = _New_node;
+        }
+
+        ++_Mysize;
+    }
+
+    pool_allocator::size_type pool_allocator::_Free_block_list::_Size() const noexcept {
         return _Mysize;
     }
 
-    pool_allocator::size_type pool_allocator::_List::_Reserve_block(const size_type _Size) noexcept {
-        for (_List_node* _Node = _Mytail; _Node != nullptr; _Node = _Node->_Prev) {
-            if (_Node->_Size >= _Size) { // found block of at least requested size, use it
+    pool_allocator::size_type pool_allocator::_Free_block_list::_Reserve_block(const size_type _Size) noexcept {
+        _List_node* _Selected = nullptr;
+        _List_node* _Prev     = nullptr;
+        for (_List_node* _Node = _Myhead; _Node != nullptr; _Prev = _Node, _Node = _Node->_Next) {
+            if (_Node->_Size == _Size) { // exact match, use the whole block
                 const size_type _Off = _Node->_Off;
-                if (_Node->_Size == _Size) { // use the whole block
-                    _Delete_node(_Node);
-                } else { // use some part of the block
-                    _Node->_Off  += _Size;
-                    _Node->_Size -= _Size;
-                }
-
+                _Delete_node_directly(_Prev, _Node);
                 return _Off;
+            }
+
+            if (_Node->_Size > _Size && (!_Selected || _Node->_Size < _Selected->_Size)) {
+                // either no node is selected or a better candidate is found
+                _Selected = _Node;
             }
         }
 
-        return static_cast<size_type>(-1); // not found
+        if (!_Selected) { // no suitable block found
+            return static_cast<size_type>(-1);
+        }
+
+        // use part of the selected block
+        const size_type _Off = _Selected->_Off;
+        _Selected->_Off     += _Size;
+        _Selected->_Size    -= _Size;
+        return _Off;
     }
 
-    void pool_allocator::_List::_Release_block(const size_type _Off, const size_type _Size) {
+    void pool_allocator::_Free_block_list::_Release_block(const size_type _Off, const size_type _Size) {
+        if (_Off == 0) { // release a block whose offset is zero (always the first block)
+            _Release_block_zero(_Size);
+            return;
+        }
+
         if (_Merge_block(_Off, _Size)) { // block merged, break
             return;
         }
 
-        _List_node* const _New_node = _Create_node();
+        _List_node* const _New_node = _List_node::_Create();
         _New_node->_Off             = _Off;
         _New_node->_Size            = _Size;
-        if (_Mytail) { // allocate the next node
+        if (_Myhead) { // insert a new node
             _Insert_node(_New_node);
-        } else { // allocate the first node
+        } else { // set a new head
             _Myhead = _New_node;
-            _Mytail = _New_node;
         }
 
         ++_Mysize;
@@ -189,13 +259,23 @@ namespace mjx {
     }
 
     void pool_allocator::deallocate(pointer _Ptr, const size_type _Count) noexcept {
-        if (_Ptr && _Count > 0) {
-            if (_Myres.contains(_Ptr, _Count)) { // _Ptr allocated from the associated resource
+        if (_Myres.contains(_Ptr, _Count)) { // _Ptr allocated from the associated resource
+            try {
                 _Mylist._Release_block(
                     static_cast<unsigned char*>(_Ptr) - static_cast<unsigned char*>(_Myres.data()), _Count);
+            } catch (...) {
+                // Note: Since deallocate() must be 'noexcept', it cannot throw any exceptions internally.
+                //       In debug mode, _INTERNAL_ASSERT provides helpful feedback by reporting the failure.
+                //       However, in release mode, _INTERNAL_ASSERT doesn't report any messages. Therefore,
+                //       abort() is called in release mode to terminate the program immediately, as such
+                //       failure can lead to various unexpected and unpredictable behaviors.
+#ifdef _DEBUG
+                _INTERNAL_ASSERT(false, "allocation failure during block release");
+#else // ^^^ _DEBUG ^^^ / vvv NDEBUG vvv
+                ::abort();
+#endif // _DEBUG
             }
         }
-
     }
 
     pool_allocator::size_type pool_allocator::max_size() const noexcept {

--- a/tests/src/pool_allocator/test.cpp
+++ b/tests/src/pool_allocator/test.cpp
@@ -10,6 +10,8 @@
 #include <mjmem/pool_allocator.hpp>
 #include <mjmem/pool_resource.hpp>
 #include <mjmem/synchronized_allocator.hpp>
+#include <random>
+#include <vector>
 
 namespace mjx {
     TEST(pool_allocator, allocate) {
@@ -75,5 +77,56 @@ namespace mjx {
         EXPECT_NE(_Pool_al, _Block_al);
         EXPECT_NE(_Pool_al, _Dynamic_al);
         EXPECT_NE(_Pool_al, _Sync_al);
+    }
+
+    struct memory_block {
+        void* _Ptr;
+        size_t _Size;
+    };
+
+    inline memory_block allocate_block(pool_allocator& _Al, const size_t _Size) {
+        return {_Al.allocate(_Size), _Size};
+    }
+
+    inline void deallocate_block(pool_allocator& _Al, memory_block& _Block) noexcept {
+        _Al.deallocate(_Block._Ptr, _Block._Size);
+    }
+
+    inline size_t random_from_range(const size_t _Min, const size_t _Max) noexcept {
+        static ::std::random_device _Device;
+#ifdef _M_X64
+        static ::std::mt19937_64 _Engine(_Device());
+#else // ^^^ _M_X64 ^^^ / vvv _M_IX86 vvv
+        static ::std::mt19937 _Engine(_Device());
+#endif // _M_X64
+        return ::std::uniform_int_distribution<size_t>{_Min, _Max}(_Engine);
+    }
+
+    TEST(pool_allocator, block_merging) {
+        pool_resource _Res(128);
+        pool_allocator _Al(_Res);
+        
+        // Note: This test is designed to evaluate the pool_allocator's block merging
+        //       mechanism for anti-fragmentation. The test allocates an array of blocks
+        //       with predefined sizes in random order and subsequently deallocates them,
+        //       also in random order. The expected outcome is that the allocator will
+        //       consolidate all blocks into a single large memory block.
+        ::std::vector<size_t> _Sizes = {64, 32, 16, 8, 8};
+        ::std::vector<memory_block> _Blocks;
+        _Blocks.reserve(_Sizes.size());
+        while (!_Sizes.empty()) { // allocate blocks in random order
+            const size_t _Idx = random_from_range(0, _Sizes.size() - 1);
+            _Blocks.push_back(allocate_block(_Al, _Sizes[_Idx]));
+            _Sizes.erase(_Sizes.begin() + _Idx);
+        }
+
+        while (!_Blocks.empty()) { // deallocate blocks in random order
+            const size_t _Idx = random_from_range(0, _Blocks.size() - 1);
+            deallocate_block(_Al, _Blocks[_Idx]);
+            _Blocks.erase(_Blocks.begin() + _Idx);
+        }
+
+        // verify that all blocks have been consolidated into a single large block
+        EXPECT_EQ(_Al.free_blocks(), 1);
     }
 } // namespace mjx


### PR DESCRIPTION
Resolves #47, also improves the documentation slightly.