### PR TITLE
`<pool_allocator>`: Remove `pool_allocator::free_blocks()`

### DIFF
--- a/docs/reference/pool_allocator/pool_allocator-free_blocks.md
+++ b/docs/reference/pool_allocator/pool_allocator-free_blocks.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+> **Important**: This function has been deprecated and removed from the library since version 2.0.0.
+
 Retrieves the number of free blocks.
 
 ## Syntax
@@ -33,7 +35,7 @@ of free blocks.
 |-------------------------|------------------------|
 | Include header          | `<pool_allocator.hpp>` |
 | Minimum library version | `1.0.0`                |
-| Maximum library version | `N/A`                  |
+| Maximum library version | `1.0.2`                |
 
 ## See also
 

--- a/docs/reference/pool_allocator/pool_allocator.md
+++ b/docs/reference/pool_allocator/pool_allocator.md
@@ -29,6 +29,10 @@ public:
     size_type max_size() const noexcept override;
     bool is_equal(const allocator& _Other) const noexcept override;
 
+#if !_MJMEM_VERSION_SUPPORTED(2, 0, 0)
+    size_type free_blocks() const noexcept;
+#endif // !_MJMEM_VERSION_SUPPORTED(2, 0, 0)
+
 #if _MJMEM_VERSION_SUPPORTED(2, 0, 0)
     const pool_resource& resource() const noexcept;
 #endif // _MJMEM_VERSION_SUPPORTED(2, 0, 0)

--- a/src/mjmem/pool_allocator.cpp
+++ b/src/mjmem/pool_allocator.cpp
@@ -287,10 +287,6 @@ namespace mjx {
         return _Other_ptr ? _Myres == _Other_ptr->_Myres && _Mymax == _Other_ptr->_Mymax : false;
     }
 
-    pool_allocator::size_type pool_allocator::free_blocks() const noexcept {
-        return _Mylist._Size();
-    }
-
 #if _MJMEM_VERSION_SUPPORTED(2, 0, 0)
     const pool_resource& pool_allocator::resource() const noexcept {
         return _Myres;

--- a/src/mjmem/pool_allocator.hpp
+++ b/src/mjmem/pool_allocator.hpp
@@ -43,9 +43,6 @@ namespace mjx {
         // compares for equality with another allocator
         bool is_equal(const allocator& _Other) const noexcept override;
 
-        // returns the number of free blocks
-        size_type free_blocks() const noexcept;
-
 #if _MJMEM_VERSION_SUPPORTED(2, 0, 0)
         // returns the associated resource
         const pool_resource& resource() const noexcept;

--- a/tests/src/pool_allocator/test.cpp
+++ b/tests/src/pool_allocator/test.cpp
@@ -126,7 +126,10 @@ namespace mjx {
             _Blocks.erase(_Blocks.begin() + _Idx);
         }
 
-        // verify that all blocks have been consolidated into a single large block
-        EXPECT_EQ(_Al.free_blocks(), 1);
+        // verify that all blocks have been consolidated into a single large block,
+        // allowing allocation of the entire block
+        void* _Ptr = _Al.allocate(128);
+        EXPECT_NE(_Ptr, nullptr);
+        _Al.deallocate(_Ptr, 128);
     }
 } // namespace mjx


### PR DESCRIPTION
Resolves #51