### PR TITLE
Track allocations in `pool_resource`-based allocators

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(MJMEM_SRC_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/synchronized_allocator.cpp"
 )
 set(MJMEM_IMPL_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/allocation_tracking.hpp"    
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/bitops.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/global_allocator.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/main.cpp"

--- a/src/mjmem/block_allocator.cpp
+++ b/src/mjmem/block_allocator.cpp
@@ -128,8 +128,8 @@ namespace mjx {
 
 #ifdef _DEBUG
         const mjmem_impl::_Memory_block _Block = {_Ptr, _Bytes};
-        if (!_Myabl->_Is_block_registered(_Block)) { // block not registered, break
-            return;
+        if (!_Myabl->_Is_block_registered(_Block)) { // block not registered, report an error
+            _REPORT_ERROR("attempt to deallocate a non-allocated block");
         }
 #endif // _DEBUG
 

--- a/src/mjmem/block_allocator.hpp
+++ b/src/mjmem/block_allocator.hpp
@@ -11,6 +11,12 @@
 #include <mjmem/pool_resource.hpp>
 
 namespace mjx {
+#ifdef _DEBUG
+    namespace mjmem_impl {
+        class _Allocated_block_list;
+    } // namespace mjmem_impl
+#endif // _DEBUG
+
     class _MJMEM_API block_allocator : public allocator { // fixed-size block allocator
     public:
         using value_type      = allocator::value_type;
@@ -86,6 +92,9 @@ namespace mjx {
         size_type _Myblock;
 #pragma warning(suppress : 4251) // C4251: _Bitmap needs to have dll-interface
         _Bitmap _Mymap;
+#ifdef _DEBUG
+        mjmem_impl::_Allocated_block_list* _Myabl; // list of allocated blocks (only in debug mode)
+#endif // _DEBUG
     };
 } // namespace mjx
 

--- a/src/mjmem/impl/allocation_tracking.hpp
+++ b/src/mjmem/impl/allocation_tracking.hpp
@@ -1,0 +1,148 @@
+// allocation_tracking.hpp
+
+// Copyright (c) Mateusz Jandura. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#ifndef _MJMEM_IMPL_ALLOCATION_TRACKING_HPP_
+#define _MJMEM_IMPL_ALLOCATION_TRACKING_HPP_
+#include <cstdlib>
+#include <mjmem/dynamic_allocator.hpp>
+#include <mjmem/impl/global_allocator.hpp>
+#include <mjmem/impl/utils.hpp>
+#include <mjmem/object_allocator.hpp>
+
+namespace mjx {
+    namespace mjmem_impl {
+        struct _Memory_block {
+            void* _Ptr   = nullptr;
+            size_t _Size = 0;
+        };
+
+        constexpr bool operator==(const _Memory_block& _Left, const _Memory_block& _Right) noexcept {
+            return _Left._Ptr == _Right._Ptr && _Left._Size == _Right._Size;
+        }
+
+        class _Allocated_block_list { // singly-linked list of allocated blocks
+        public:
+            _Allocated_block_list() noexcept : _Myhead(nullptr), _Mytail(nullptr), _Mysize(0) {}
+
+            ~_Allocated_block_list() noexcept {
+                if (_Myhead) { // deallocate all nodes
+                    dynamic_allocator& _Al = _Get_internal_allocator();
+                    for (_List_node* _Node = _Myhead, *_Next; _Node != nullptr; _Node = _Next) {
+                        _Next = _Node->_Next;
+                        ::mjx::delete_object_using_allocator(_Node, _Al);
+                    }
+
+                    _Myhead = nullptr;
+                    _Mytail = nullptr;
+                    _Mysize = 0;
+                }
+            }
+
+            _Allocated_block_list(const _Allocated_block_list&)            = delete;
+            _Allocated_block_list& operator=(const _Allocated_block_list&) = delete;
+
+            static _Allocated_block_list* _Create() {
+                // create a new list using a stateless allocator to avoid internal errors
+                return ::mjx::create_object_using_allocator<_Allocated_block_list>(_Get_internal_allocator());
+            }
+
+            static void _Delete(_Allocated_block_list* const _List) noexcept {
+                // delete an existing list using a stateless allocator to avoid internal errors
+                ::mjx::delete_object_using_allocator(_List, _Get_internal_allocator());
+            }
+
+            bool _Is_block_registered(const _Memory_block& _Block) const noexcept {
+                // check whether the list has a node that holds the given memory block
+                if (_Mysize == 0) { // empty list, definitely not registered
+                    return false;
+                }
+
+                for (_List_node* _Node = _Myhead; _Node != nullptr; _Node = _Node->_Next) {
+                    if (_Node->_Block == _Block) { // searched block found, break
+                        return true;
+                    }
+                }
+
+                return false; // not found
+            }
+
+            void _Register_block(const _Memory_block& _Block) noexcept {
+                // insert a new node that will hold the given memory block
+                try {
+                    _List_node* const _New_node = _List_node::_Create();
+                    _New_node->_Block           = _Block;
+                    if (_Mytail) { // insert a next node
+                        _Mytail->_Next = _New_node;
+                    } else { // set a new head
+                        _Myhead = _New_node;
+                    }
+
+                    _Mytail = _New_node; // set a new tail
+                    ++_Mysize;
+                } catch (...) {
+                    // Note: This function must not throw exceptions to maintain allocator::deallocate() noexcept.
+                    //       Ignoring exceptions is not advisable, so the function will abort, optionally
+                    //       reporting an error in debug mode.
+#ifdef _DEBUG
+                    _REPORT_ERROR("allocation failure during block registration");
+#else // ^^^ _DEBUG ^^^ / vvv NDEBUG vvv
+                    ::abort();
+#endif // _DEBUG
+                }
+            }
+
+            void _Unregister_block(const _Memory_block& _Block) noexcept {
+                // remove a node that holds the given memory block, do nothing if such a node not exists
+                for (_List_node* _Node = _Myhead, *_Prev = nullptr;
+                    _Node != nullptr; _Prev = _Node, _Node = _Node->_Next) {
+                    if (_Node->_Block == _Block) { // searched block found, remove the node that holds it
+                        _Unlink_node(_Prev, _Node);
+                        _List_node::_Delete(_Node);
+                        --_Mysize;
+                        break;
+                    }
+                }
+            }
+
+        private:
+            struct _List_node {
+                _List_node* _Next = nullptr; // pointer to the next node
+                _Memory_block _Block; // the stored block
+
+                static _List_node* _Create() {
+                    // create a new node using a stateless allocator to avoid internal errors
+                    return ::mjx::create_object_using_allocator<_List_node>(_Get_internal_allocator());
+                }
+
+                static void _Delete(_List_node* const _Node) noexcept {
+                    // delete an existing node using a stateless allocator to avoid internal errors
+                    return ::mjx::delete_object_using_allocator(_Node, _Get_internal_allocator());
+                }
+            };
+
+            void _Unlink_node(_List_node* const _Prev, _List_node* const _Node) noexcept {
+                // unlink _Node using _Prev as the previous node, since _Node has no _Prev pointer
+                if (_Prev) { // break connection with the previous node
+                    _Prev->_Next = _Node->_Next;
+                    if (!_Node->_Next) { // set a new tail
+                        _Mytail = _Prev;
+                    }
+                } else { // set a new head
+                    _Myhead = _Node->_Next;
+                    if (!_Node->_Next) { // mark the list as empty
+                        _Mytail = nullptr;
+                    }
+                }
+            }
+
+            _List_node* _Myhead; // pointer to the first node
+            _List_node* _Mytail; // pointer to the last node (for O(1) insertion)
+            size_t _Mysize; // total number of nodes
+        };
+    } // namespace mjmem_impl
+} // namespace mjx
+
+#endif // _MJMEM_IMPL_ALLOCATION_TRACKING_HPP_

--- a/src/mjmem/impl/global_allocator.hpp
+++ b/src/mjmem/impl/global_allocator.hpp
@@ -39,6 +39,12 @@ namespace mjx {
             dynamic_allocator _Mydef; // the default allocator that has no state or associated resource
             ::std::atomic<allocator*> _Myal; // pointer to the currently used allocator
         };
+
+        inline dynamic_allocator& _Get_internal_allocator() noexcept {
+            // retrieve the singleton dynamic_allocator used for all internal allocations
+            static dynamic_allocator _Al;
+            return _Al;
+        }
     } // namespace mjmem_impl
 } // namespace mjx
 

--- a/src/mjmem/impl/utils.hpp
+++ b/src/mjmem/impl/utils.hpp
@@ -10,10 +10,11 @@
 #include <cstddef>
 #include <mjmem/impl/tinywin.hpp>
 
-// generic assert macro, useful in debug mode
-#define _INTERNAL_ASSERT(_Cond, _Msg)                                   \
-    if (!(_Cond)) {                                                     \
-        ::_CrtDbgReport(_CRT_ERROR, __FILE__, __LINE__, nullptr, _Msg); \
+// generic assertion macros, useful in debug mode
+#define _REPORT_ERROR(_Msg)           ::_CrtDbgReport(_CRT_ERROR, __FILE__, __LINE__, nullptr, _Msg)
+#define _INTERNAL_ASSERT(_Cond, _Msg) \
+    if (!(_Cond)) {                   \
+        _REPORT_ERROR(_Msg);          \
     }
 
 namespace mjx {

--- a/src/mjmem/pool_allocator.cpp
+++ b/src/mjmem/pool_allocator.cpp
@@ -267,8 +267,8 @@ namespace mjx {
 
 #ifdef _DEBUG
         const mjmem_impl::_Memory_block _Block = {_Ptr, _Count};
-        if (!_Myabl->_Is_block_registered(_Block)) { // block not registered, break
-            return;
+        if (!_Myabl->_Is_block_registered(_Block)) { // block not registered, report an error
+            _REPORT_ERROR("attempt to deallocate a non-allocated block");
         }
 #endif // _DEBUG
 

--- a/src/mjmem/pool_allocator.cpp
+++ b/src/mjmem/pool_allocator.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <mjmem/dynamic_allocator.hpp>
 #include <mjmem/exception.hpp>
+#include <mjmem/impl/allocation_tracking.hpp>
 #include <mjmem/impl/utils.hpp>
 #include <mjmem/object_allocator.hpp>
 #include <mjmem/pool_allocator.hpp>
@@ -13,18 +14,24 @@
 
 namespace mjx {
     pool_allocator::pool_allocator(pool_resource& _Resource, const size_type _Max_block_size)
-        : _Myres(_Resource), _Mymax((::std::min)(_Max_block_size, _Resource.size())), _Mylist() {
 #ifdef _DEBUG
+        : _Myres(_Resource), _Mymax((::std::min)(_Max_block_size, _Resource.size())), _Myfbl(),
+        _Myabl(mjmem_impl::_Allocated_block_list::_Create()) {
         if (_Mymax != unbounded_block_size) { // maximum block size specified, validate it
             _INTERNAL_ASSERT(
                 _Myres.size() >= _Mymax, "maximum block size cannot exceed the total pool resource size");
         }
+#else // ^^^ _DEBUG ^^^ / vvv NDEBUG vvv
+        : _Myres(_Resource), _Mymax((::std::min)(_Max_block_size, _Resource.size())), _Myfbl() {
 #endif // _DEBUG
-
-        _Mylist._Release_block(0, _Myres.size());
+        _Myfbl._Release_block(0, _Myres.size());
     }
 
-    pool_allocator::~pool_allocator() noexcept {}
+    pool_allocator::~pool_allocator() noexcept {
+#ifdef _DEBUG
+        mjmem_impl::_Allocated_block_list::_Delete(_Myabl);
+#endif // _DEBUG
+    }
 
     pool_allocator::_Free_block_list::_Free_block_list() noexcept : _Myhead(nullptr), _Mysize(0) {}
 
@@ -171,10 +178,6 @@ namespace mjx {
         ++_Mysize;
     }
 
-    pool_allocator::size_type pool_allocator::_Free_block_list::_Size() const noexcept {
-        return _Mysize;
-    }
-
     pool_allocator::size_type pool_allocator::_Free_block_list::_Reserve_block(const size_type _Size) noexcept {
         _List_node* _Selected = nullptr;
         _List_node* _Prev     = nullptr;
@@ -229,7 +232,7 @@ namespace mjx {
             return nullptr;
         }
 
-        const size_type _Off = _Mylist._Reserve_block(_Count);
+        const size_type _Off = _Myfbl._Reserve_block(_Count);
         return _Off != static_cast<size_type>(-1)
             ? mjmem_impl::_Adjust_address_by_offset(_Myres.data(), _Off) : nullptr;
     }
@@ -244,6 +247,9 @@ namespace mjx {
             allocation_failure::raise();
         }
 
+#ifdef _DEBUG
+        _Myabl->_Register_block(mjmem_impl::_Memory_block{_Ptr, _Count});
+#endif // _DEBUG
         return _Ptr;
     }
 
@@ -255,21 +261,33 @@ namespace mjx {
     }
 
     void pool_allocator::deallocate(pointer _Ptr, const size_type _Count) noexcept {
-        if (_Myres.contains(_Ptr, _Count)) { // _Ptr allocated from the associated resource
-            try {
-                _Mylist._Release_block(mjmem_impl::_Calculate_offset_from_address(_Myres.data(), _Ptr), _Count);
-            } catch (...) {
-                // Note: Since deallocate() must be 'noexcept', it cannot throw any exceptions internally.
-                //       In debug mode, _INTERNAL_ASSERT provides helpful feedback by reporting the failure.
-                //       However, in release mode, _INTERNAL_ASSERT doesn't report any messages. Therefore,
-                //       abort() is called in release mode to terminate the program immediately, as such
-                //       failure can lead to various unexpected and unpredictable behaviors.
+        if (!_Myres.contains(_Ptr, _Count)) { // _Ptr doesn't originate from the associated resource
+            return;
+        }
+
 #ifdef _DEBUG
-                _INTERNAL_ASSERT(false, "allocation failure during block release");
-#else // ^^^ _DEBUG ^^^ / vvv NDEBUG vvv
-                ::abort();
+        const mjmem_impl::_Memory_block _Block = {_Ptr, _Count};
+        if (!_Myabl->_Is_block_registered(_Block)) { // block not registered, break
+            return;
+        }
 #endif // _DEBUG
-            }
+
+        try {
+            _Myfbl._Release_block(mjmem_impl::_Calculate_offset_from_address(_Myres.data(), _Ptr), _Count);
+#ifdef _DEBUG
+            _Myabl->_Unregister_block(_Block);
+#endif // _DEBUG
+        } catch (...) {
+            // Note: Since deallocate() must be 'noexcept', it cannot throw any exceptions internally.
+            //       In debug mode, _INTERNAL_ASSERT provides helpful feedback by reporting the failure.
+            //       However, in release mode, _INTERNAL_ASSERT doesn't report any messages. Therefore,
+            //       abort() is called in release mode to terminate the program immediately, as such
+            //       failure can lead to various unexpected and unpredictable behaviors.
+#ifdef _DEBUG
+            _REPORT_ERROR("allocation failure during block release");
+#else // ^^^ _DEBUG ^^^ / vvv NDEBUG vvv
+            ::abort();
+#endif // _DEBUG
         }
     }
 

--- a/src/mjmem/pool_allocator.hpp
+++ b/src/mjmem/pool_allocator.hpp
@@ -11,6 +11,12 @@
 #include <mjmem/pool_resource.hpp>
 
 namespace mjx {
+#ifdef _DEBUG
+    namespace mjmem_impl {
+        class _Allocated_block_list;
+    } // namespace mjmem_impl
+#endif // _DEBUG
+
     class _MJMEM_API pool_allocator : public allocator { // variable-size block allocator
     public:
         using value_type      = allocator::value_type;
@@ -51,9 +57,6 @@ namespace mjx {
         public:        
             _Free_block_list() noexcept;
             ~_Free_block_list() noexcept;
-
-            // returns the list size
-            size_type _Size() const noexcept;
 
             // reserves a new block
             size_type _Reserve_block(const size_type _Size) noexcept;
@@ -115,7 +118,10 @@ namespace mjx {
         pool_resource& _Myres;
         size_type _Mymax; // maximum number of bytes possible to allocate
 #pragma warning(suppress : 4251) // C4251: _Free_block_list needs to have dll-interface
-        _Free_block_list _Mylist;
+        _Free_block_list _Myfbl; // list of free blocks
+#ifdef _DEBUG
+        mjmem_impl::_Allocated_block_list* _Myabl; // list of allocated blocks (only in debug mode)
+#endif // _DEBUG
     };
 } // namespace mjx
 


### PR DESCRIPTION
Resolves #53, partially implements #56