### PR TITLE
Implement Linux support

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -1,9 +1,9 @@
-# build-and-test.yml
+# build-and-test-linux.yml
 
 # Copyright (c) Mateusz Jandura. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Build and test
+name: Build and test (Linux)
 on:
   push:
     paths-ignore:
@@ -14,9 +14,10 @@ jobs:
     # Note: As pull requests are required before merging, workflows already run during review.
     #       Thus, 'main' branch pushes are skipped.
     if: ${{ github.ref_name != 'main' }}
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
+        compiler: [Clang, GCC]
         arch: [x64, x86]
         config: [Debug, Release]
 
@@ -28,9 +29,21 @@ jobs:
         run: |
           git submodule update --init --recursive
 
-      - name: Configure project
+      - name: Install Ninja
         run: |
-          cmake --preset=${{ matrix.arch }} -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+          sudo apt-get install ninja-build
+
+      - name: Configure project (Clang)
+        if: ${{ matrix.compiler == 'Clang' }}
+        run: >
+          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=clang++
+            -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+
+      - name: Configure project (GCC)
+        if: ${{ matrix.compiler == 'GCC' }}
+        run: >
+          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=g++ -DMJMEM_BUILD_BENCHMARKS=ON
+            -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Build project
         run: |

--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -36,14 +36,14 @@ jobs:
       - name: Configure project (Clang)
         if: ${{ matrix.compiler == 'Clang' }}
         run: >
-          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=clang++
+          cmake --preset=${{ matrix.arch }} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Configure project (GCC)
         if: ${{ matrix.compiler == 'GCC' }}
         run: >
-          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=g++ -DMJMEM_BUILD_BENCHMARKS=ON
-          -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+          cmake --preset=${{ matrix.arch }} -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Build project
         run: |

--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -37,13 +37,13 @@ jobs:
         if: ${{ matrix.compiler == 'Clang' }}
         run: >
           cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=clang++
-            -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+          -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Configure project (GCC)
         if: ${{ matrix.compiler == 'GCC' }}
         run: >
           cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=g++ -DMJMEM_BUILD_BENCHMARKS=ON
-            -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+          -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Build project
         run: |

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -1,0 +1,74 @@
+# build-and-test-windows.yml
+
+# Copyright (c) Mateusz Jandura. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build and test (Windows)
+on:
+  push:
+    paths-ignore:
+      - '**/**.md'
+      
+jobs:
+  build-and-test:
+    # Note: As pull requests are required before merging, workflows already run during review.
+    #       Thus, 'main' branch pushes are skipped.
+    if: ${{ github.ref_name != 'main' }}
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        compiler: [Clang, GCC, MSVC]
+        arch: [x64, x86]
+        config: [Debug, Release]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Update submodules
+        run: |
+          git submodule update --init --recursive
+
+      - name: Install Ninja
+        uses: turtlesec-no/get-ninja@main
+
+      # Note: Unlike Clang and GCC, MSVC requires specific environment variables to be set for its tools
+      #       to be properly found and used. This configuration ensures that the MSVC tools' paths are
+      #       correctly recognized. If these environment variables are not set, the MSVC tools may not
+      #       be found or used correctly, even if they are installed on the system.
+      - name: Setup environment
+        if: ${{ matrix.compiler == 'MSVC' }}
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
+          vsversion: 2022
+
+      - name: Configure project (Clang)
+        if: ${{ matrix.compiler == 'Clang' }}
+        run: >
+          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS='-target x86_64-pc-windows-gnu'
+            -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+
+      - name: Configure project (GCC)
+        if: ${{ matrix.compiler == 'GCC' }}
+        run: >
+          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=g++ -DMJMEM_BUILD_BENCHMARKS=ON
+            -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+
+      - name: Configure project (MSVC)
+        if: ${{ matrix.compiler == 'MSVC' }}
+        run: >
+          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=cl -DMJMEM_BUILD_BENCHMARKS=ON
+            -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+
+      - name: Build project
+        run: |
+          cmake --build build/${{ matrix.arch }} --preset=${{ matrix.arch }} --config ${{ matrix.config }}
+
+      - name: Install project
+        run: |
+          cmake --install build/${{ matrix.arch }} --config ${{ matrix.config }}
+
+      - name: Run tests
+        run: |
+          ctest --test-dir build/${{ matrix.arch }}/tests --output-on-failure -C ${{ matrix.config }}

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Install Ninja
         uses: turtlesec-no/get-ninja@main
 
-      # Note: Unlike Clang and GCC, MSVC requires specific environment variables to be set for its tools
-      #       to be properly found and used. This configuration ensures that the MSVC tools' paths are
-      #       correctly recognized. If these environment variables are not set, the MSVC tools may not
-      #       be found or used correctly, even if they are installed on the system.
-      - name: Setup environment
-        if: ${{ matrix.compiler == 'MSVC' }}
+      # Note: Unlike GCC, Clang (with the MSVC toolchain) and MSVC require specific environment variables to
+      #       be set for their tools to be properly found and used. This configuration ensures that the MSVC
+      #       tools' paths are correctly recognized. If these environment variables are not set,
+      #       the MSVC tools may not be found or used correctly, even if they are installed on the system.
+      - name: Setup compiler toolchain
+        if: ${{ matrix.compiler == 'Clang' || matrix.compiler == 'MSVC' }}
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch }}
@@ -46,8 +46,8 @@ jobs:
       - name: Configure project (Clang)
         if: ${{ matrix.compiler == 'Clang' }}
         run: >
-          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS='-target x86_64-pc-windows-gnu'
-          -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=clang++ -DMJMEM_BUILD_BENCHMARKS=ON
+          -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Configure project (GCC)
         if: ${{ matrix.compiler == 'GCC' }}

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -43,23 +43,31 @@ jobs:
           arch: ${{ matrix.arch }}
           vsversion: 2022
 
-      - name: Configure project (Clang)
-        if: ${{ matrix.compiler == 'Clang' }}
+      - name: Configure project (x64 Clang)
+        if: ${{ matrix.compiler == 'Clang' && matrix.arch == 'x64' }}
         run: >
-          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=clang++ -DMJMEM_BUILD_BENCHMARKS=ON
-          -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+          cmake --preset=${{ matrix.arch }} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          -DCMAKE_C_FLAGS="-target x86_64-pc-windows-msvc" -DCMAKE_CXX_FLAGS="-target x86_64-pc-windows-msvc"
+          -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+
+      - name: Configure project (x86 Clang)
+        if: ${{ matrix.compiler == 'Clang' && matrix.arch == 'x86' }}
+        run: >
+          cmake --preset=${{ matrix.arch }} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          -DCMAKE_C_FLAGS="-target i386-pc-windows-msvc" -DCMAKE_CXX_FLAGS="-target i386-pc-windows-msvc"
+          -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Configure project (GCC)
         if: ${{ matrix.compiler == 'GCC' }}
         run: >
-          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=g++ -DMJMEM_BUILD_BENCHMARKS=ON
-          -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+          cmake --preset=${{ matrix.arch }} -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Configure project (MSVC)
         if: ${{ matrix.compiler == 'MSVC' }}
         run: >
-          cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=cl -DMJMEM_BUILD_BENCHMARKS=ON
-          -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+          cmake --preset=${{ matrix.arch }} -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
+          -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Build project
         run: |

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -47,19 +47,19 @@ jobs:
         if: ${{ matrix.compiler == 'Clang' }}
         run: >
           cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS='-target x86_64-pc-windows-gnu'
-            -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+          -DMJMEM_BUILD_BENCHMARKS=ON -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Configure project (GCC)
         if: ${{ matrix.compiler == 'GCC' }}
         run: >
           cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=g++ -DMJMEM_BUILD_BENCHMARKS=ON
-            -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+          -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Configure project (MSVC)
         if: ${{ matrix.compiler == 'MSVC' }}
         run: >
           cmake --preset=${{ matrix.arch }} -DCMAKE_CXX_COMPILER=cl -DMJMEM_BUILD_BENCHMARKS=ON
-            -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
+          -DMJMEM_BUILD_TESTS=ON -DMJMEM_INSTALL_LIBRARY=ON
 
       - name: Build project
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 /build
+/CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,7 @@
 cmake_minimum_required(VERSION 3.21.0)
 project(mjmem_library LANGUAGES CXX)
 
-# check if the MJX_PLATFORM_ARCH variable is not defined, if it's undefined,
-# set its value based on the CMAKE_GENERATOR_PLATFORM predefined variable
-if(NOT DEFINED MJX_PLATFORM_ARCH)
-    if(CMAKE_GENERATOR_PLATFORM STREQUAL "x64")
-        set(MJX_PLATFORM_ARCH "x64")
-    elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "Win32")
-        set(MJX_PLATFORM_ARCH "x86") # translate Win32 into x86
-    endif()
-endif()
-
-# check if the platform architecture is supported
+# check if the platform architecture is supported (MJX_PLATFORM_ARCH defined in presets)
 if(NOT ${MJX_PLATFORM_ARCH} MATCHES "^x64$|^x86$")
     message(FATAL_ERROR "The MJMEM library can only be built for x64 and x86 architectures.")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,15 +9,15 @@
         {
             "name": "base",
             "hidden": true,
-            "generator": "Visual Studio 17 2022",
+            "generator": "Ninja Multi-Config",
             "binaryDir": "${sourceDir}/build/${presetName}"
         },
         {
             "name": "x64",
             "inherits": "base",
-            "description": "x64 Visual Studio 2022 Configuration",
+            "description": "x64 Ninja Configuration",
             "architecture": {
-                "strategy": "set",
+                "strategy": "external",
                 "value": "x64"
             },
             "cacheVariables": {
@@ -27,10 +27,10 @@
         {
             "name": "x86",
             "inherits": "base",
-            "description": "x86 Visual Studio 2022 Configuration",
+            "description": "x86 Ninja Configuration",
             "architecture": {
-                "strategy": "set",
-                "value": "Win32"
+                "strategy": "external",
+                "value": "x86"
             },
             "cacheVariables": {
                 "MJX_PLATFORM_ARCH": "x86"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Follow these steps to build and install MJMEM on your system:
 1. Install the required tools.
 
     - Download and install [CMake][] 3.21.0 or later.
-    - Ensure you have a compatible compiler that supports C++20.
+    - Download [Ninja][] 1.11.0 or later.
+    - Ensure you have a compatible compiler that supports C++20:
+        - On Linux, you can use Clang or GCC.
+        - On Windows, you can use Clang (with the MSVC toolchain), GCC (MinGW port), or MSVC.
 
 2. Clone the repository.
 
@@ -27,10 +30,29 @@ Follow these steps to build and install MJMEM on your system:
 
 4. Build and, optionally, install the project.
 
-    - To build tests, benchmarks, or install the library, consider setting the `MJMEM_BUILD_BENCHMARKS`, `MJMEM_BUILD_TESTS`, and `MJMEM_INSTALL_LIBRARY` options, respectively.
+    - To build tests, benchmarks, or install the library, consider setting the `MJMEM_BUILD_BENCHMARKS`, `MJMEM_BUILD_TESTS`, and
+`MJMEM_INSTALL_LIBRARY` options, respectively.
     - Invoke `cmake --preset=<preset> [options...]`.
     - Build the project with `cmake --build build/<arch> --preset=<preset> --config <config>`.
     - To install the library, invoke `cmake --install build/<arch> --config <config>`.
+
+Notes for Windows users:
+
+- If you are using Clang, you must use the MSVC toolchain. Ensure the correct target is set for different architectures:
+    - For x64, use the `x86_64-pc-windows-msvc` target.
+    - For x86, use the `i386-pc-windows-msvc` target.
+- Set the target using the `-DCMAKE_CXX_FLAGS='-target ...'` option.
+- If using MSVC (or its toolchain), set up the environment by using a special command-line like the
+**Developer Command Prompt For VS 2022** or by running **vcvarsall.bat**.
+
+To specify compilers, use the `-DCMAKE_C_COMPILER` and `-DCMAKE_CXX_COMPILER` options. In some cases, setting the C compiler
+(with flags if using Clang) is required to successfully configure and build the project.
+
+The following compilers are supported:
+
+- Clang: **clang** and **clang++**
+- GCC: **gcc** and **g++**
+- MSVC: **cl** only
 
 # Testing and benchmarking
 
@@ -48,17 +70,24 @@ To run a benchmark:
 2. Change the current directory to the cloned `mjmem` directory.
 3. Invoke `build\<arch>\benchmarks\<config>\<benchmark-name>`.
 
-Note that while all tests are invoked by CTest in a single run, benchmarks are standalone programs that must be invoked separately.
+Note that while all tests are invoked by CTest in a single run, benchmarks are standalone programs that must be invoked separately. 
+Additionally, on Linux, you should use forward slashes (`/`) instead of backslashes (`\`) to correctly run benchmarks.
 
 # How to consume
 
-To use the library:
+To use the library on Windows:
 
 1. Include the `mjmem` header files directory.
 2. Link the `mjmem.lib` static library.
-3. Copy the `mjmem.dll` dynamic library to the directory where the executable that uses MJMEM is located.
+3. Copy the `mjmem.dll` dynamic library to the directory where the executable that uses the MJMEM is located.
 
-To integrate into another project:
+To use the library on Linux:
+
+1. Include the `mjmem` header files directory.
+2. Link the `mjmem.so` shared object.
+3. Copy the `mjmem.so` shared object to the directory where the executable that uses the MJMEM is located. 
+
+To integrate into another project on Windows:
 
 1. Add `mjmem` as a submodule.
 
@@ -84,12 +113,39 @@ To integrate into another project:
     )
     ```
 
+To integrate into another project on Linux:
+
+1. Add `mjmem` as a submodule.
+
+    - Open a command-line interface.
+    - Invoke `git submodule add mjmem https://github.com/MateuszJanduraUszu/mjmem.git <path>`.
+
+2. In your CMake script, add `mjmem` as an external target.
+
+    - In your top-level `CMakeLists.txt`, add `add_subdirectory(<path-to-mjmem>)`.
+
+3. Include the `mjmem` header files directory and link the generated shared object.
+
+    - Include the header files directory with `target_include_directories(<target> <scope> "<path-to-mjmem>/src")`.
+    - Link the shared object with `target_link_libraries(<target> <scope> mjmem)`.
+
+4. Copy the `mjmem.so` shared object to your project's output directory.
+
+    ```cmake
+    add_custom_command(TARGET <target> POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        "$<TARGET_FILE:mjmem>"
+        "$<TARGET_FILE_DIR:<target>>"
+    )
+    ```
+
 Replace the placeholders with the appropriate values for your project.
 
 # Compatibility
 
-The MJMEM library is designed to work with Windows 10 and above. While it is optimized for these versions, it may also be 
-compatible with older Windows versions. However, official support is focused on Windows 10 and newer versions.
+The MJMEM library is designed to work with Windows 10 and above, as well as the latest versions of Linux distributions. While it is 
+optimized for these platforms, it may also be compatible with older Windows and Linux versions. However, official support is focused on 
+Windows 10 and newer versions, along with the most recent Linux distributions.
 
 # Questions and support
 
@@ -108,5 +164,6 @@ SPDX-License-Identifier: Apache-2.0
 [License]: LICENSE
 [Documentation]: docs/README.md
 [CMake]: https://cmake.org/download
+[Ninja]: https://github.com/ninja-build/ninja/releases
 [issues]: https://github.com/MateuszJanduraUszu/mjmem/issues
 [email]: mailto:mjandura03@gmail.com

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -14,15 +14,6 @@ if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     target_compile_options(benchmark PRIVATE -Wno-invalid-offsetof)
 endif()
 
-function(copy_files_required_for_benchmark benchmark_name)
-    # copy all required files to the output directory of the specified benchmark
-    add_custom_command(TARGET ${benchmark_name} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "$<TARGET_FILE:mjmem>"
-        "$<TARGET_FILE_DIR:${benchmark_name}>"
-    )
-endfunction()
-
 function(add_isolated_benchmark benchmark_name benchmark_path)
     # create an executable for the specified benchmark, linking against necessary libraries
     add_executable(${benchmark_name} ${benchmark_path})
@@ -37,10 +28,22 @@ function(add_isolated_benchmark benchmark_name benchmark_path)
         # link against Shlwapi.lib, a Windows-specific statically-linked library
         target_link_libraries(${benchmark_name} PRIVATE Shlwapi)
     endif()
-
-    copy_files_required_for_benchmark(${benchmark_name})
 endfunction()
 
 add_isolated_benchmark(benchmark_bitops "src/bitops/benchmark.cpp")
 add_isolated_benchmark(benchmark_block_allocator "src/block_allocator/benchmark.cpp")
 add_isolated_benchmark(benchmark_pool_allocator "src/pool_allocator/benchmark.cpp")
+
+# use a custom target to combine all targets into a single one,
+# this allows only one post-build call instead of per-benchmark copying
+add_custom_target(mjmem_and_benchmarks ALL DEPENDS
+    mjmem
+    benchmark_bitops
+    benchmark_block_allocator
+    benchmark_pool_allocator
+)
+add_custom_command(TARGET mjmem_and_benchmarks POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "$<TARGET_FILE:mjmem>"
+    "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>" # copy to the benchmarks' output directory
+)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -32,6 +32,10 @@ function(add_isolated_benchmark benchmark_name benchmark_path)
     copy_files_required_for_benchmark(${benchmark_name})
 endfunction()
 
-add_isolated_benchmark(benchmark_bitops "src/bitops/benchmark.cpp")
-add_isolated_benchmark(benchmark_block_allocator "src/block_allocator/benchmark.cpp")
+# Note: The 'bitops' and 'block_allocator' benchmarks are currently blocked until endianness
+#       support is added to the library. This is because these tests rely on direct bit
+#       manipulation, which is not supported in the current Linux implementation.
+
+# add_isolated_benchmark(benchmark_bitops "src/bitops/benchmark.cpp")
+# add_isolated_benchmark(benchmark_block_allocator "src/block_allocator/benchmark.cpp")
 add_isolated_benchmark(benchmark_pool_allocator "src/pool_allocator/benchmark.cpp")

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -9,11 +9,15 @@ project(mjmem_benchmarks LANGUAGES CXX)
 # build Google Benchmark before building any benchmarks
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 add_subdirectory(google-benchmark "${CMAKE_CURRENT_BINARY_DIR}/google-benchmark" EXCLUDE_FROM_ALL)
+if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # suppress -Winvalid-offsetof warning to compile Google Benchmark with Clang on Windows
+    target_compile_options(benchmark PRIVATE -Wno-invalid-offsetof)
+endif()
 
 function(copy_files_required_for_benchmark benchmark_name)
     # copy all required files to the output directory of the specified benchmark
     add_custom_command(TARGET ${benchmark_name} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "$<TARGET_FILE:mjmem>"
         "$<TARGET_FILE_DIR:${benchmark_name}>"
     )
@@ -28,14 +32,15 @@ function(add_isolated_benchmark benchmark_name benchmark_path)
         "${CMAKE_CURRENT_SOURCE_DIR}/../src"
         "${benchmark_SOURCE_DIR}/include"
     )
-    target_link_libraries(${benchmark_name} PRIVATE benchmark mjmem Shlwapi)
+    target_link_libraries(${benchmark_name} PRIVATE benchmark mjmem)
+    if(WIN32)
+        # link against Shlwapi.lib, a Windows-specific statically-linked library
+        target_link_libraries(${benchmark_name} PRIVATE Shlwapi)
+    endif()
+
     copy_files_required_for_benchmark(${benchmark_name})
 endfunction()
 
-# Note: The 'bitops' and 'block_allocator' benchmarks are currently blocked until endianness
-#       support is added to the library. This is because these tests rely on direct bit
-#       manipulation, which is not supported in the current Linux implementation.
-
-# add_isolated_benchmark(benchmark_bitops "src/bitops/benchmark.cpp")
-# add_isolated_benchmark(benchmark_block_allocator "src/block_allocator/benchmark.cpp")
+add_isolated_benchmark(benchmark_bitops "src/bitops/benchmark.cpp")
+add_isolated_benchmark(benchmark_block_allocator "src/block_allocator/benchmark.cpp")
 add_isolated_benchmark(benchmark_pool_allocator "src/pool_allocator/benchmark.cpp")

--- a/benchmarks/src/bitops/benchmark.cpp
+++ b/benchmarks/src/bitops/benchmark.cpp
@@ -6,6 +6,8 @@
 #include <benchmark/benchmark.h>
 #include <mjmem/impl/bitops.hpp>
 
+// the benchmarks assume the platform is little-endian
+
 namespace mjx {
     using namespace mjmem_impl;
 
@@ -1052,6 +1054,7 @@ void set_benchmark_properties(auto* const _Benchmark) {
     _Benchmark->DenseRange(1, 10)->Unit(::benchmark::TimeUnit::kNanosecond);
 }
 
+#ifdef _MJX_LITTLE_ENDIAN
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<64>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<128>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<256>)->Apply(set_benchmark_properties);
@@ -1060,5 +1063,6 @@ BENCHMARK(::mjx::bm_find_contiguous_zero_bits<1024>)->Apply(set_benchmark_proper
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<2048>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<4096>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<8192>)->Apply(set_benchmark_properties);
+#endif // _MJX_LITTLE_ENDIAN
 
 BENCHMARK_MAIN();

--- a/benchmarks/src/block_allocator/benchmark.cpp
+++ b/benchmarks/src/block_allocator/benchmark.cpp
@@ -7,6 +7,8 @@
 #include <mjmem/block_allocator.hpp>
 #include <mjmem/pool_resource.hpp>
 
+// the benchmarks assume the platform is little-endian
+
 namespace mjx {
     inline constexpr size_t _Block_size = 16;
 
@@ -37,6 +39,7 @@ void set_benchmark_properties(auto* const _Benchmark) {
     _Benchmark->DenseRange(1, 10)->Unit(::benchmark::TimeUnit::kNanosecond);
 }
 
+#ifdef _MJX_LITTLE_ENDIAN
 BENCHMARK(::mjx::bm_allocate_block_allocator<128>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_allocate_block_allocator<256>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_allocate_block_allocator<512>)->Apply(set_benchmark_properties);
@@ -44,5 +47,6 @@ BENCHMARK(::mjx::bm_allocate_block_allocator<1024>)->Apply(set_benchmark_propert
 BENCHMARK(::mjx::bm_allocate_block_allocator<2048>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_allocate_block_allocator<4096>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_allocate_block_allocator<8192>)->Apply(set_benchmark_properties);
+#endif // _MJX_LITTLE_ENDIAN
 
 BENCHMARK_MAIN();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,7 +94,7 @@ source_group("res" FILES ${MJMEM_RES_FILES})
 add_library(mjmem SHARED ${MJMEM_INC_FILES} ${MJMEM_SRC_FILES} ${MJMEM_IMPL_FILES})
 target_compile_definitions(mjmem PRIVATE _MJMEM_BUILD=1 PUBLIC ${MJX_BASE_DEFS})
 target_compile_features(mjmem PRIVATE cxx_std_20)
-target_include_directories(mjmem PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(mjmem PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Note: RC files are used only on Windows and are compiled with rc.exe (MSVC), windres.exe (GCC),
 #       or llvm-windres.exe (Clang). Therefore, they are included only when compiling for Windows.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,12 +56,18 @@ else()
     message(FATAL_ERROR "Unsupported platform detected.")
 endif()
 
-# detect the compiler and set the corresponding macro, terminate if the compiler is not recognized 
+# detect the compiler and set the corresponding macro, terminate if the compiler is not recognized
+set(is_clang FALSE)
+set(is_gcc FALSE)
+set(is_msvc FALSE)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(is_clang TRUE)
     list(APPEND MJX_BASE_DEFS _MJX_CLANG=1)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(is_gcc TRUE)
     list(APPEND MJX_BASE_DEFS _MJX_GCC=1)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set(is_msvc TRUE)
     list(APPEND MJX_BASE_DEFS _MJX_MSVC=1)
 else()
     # unrecognized compiler, report an error and terminate
@@ -95,6 +101,23 @@ add_library(mjmem SHARED ${MJMEM_INC_FILES} ${MJMEM_SRC_FILES} ${MJMEM_IMPL_FILE
 target_compile_definitions(mjmem PRIVATE _MJMEM_BUILD=1 PUBLIC ${MJX_BASE_DEFS})
 target_compile_features(mjmem PRIVATE cxx_std_20)
 target_include_directories(mjmem PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(mjmem PROPERTIES PREFIX "") # prevent compilers from adding "lib" prefix
+if(${is_clang})
+    # add '-fsized-deallocation' flag to enable sized operator delete
+    target_compile_options(mjmem PUBLIC -fsized-deallocation)
+endif()
+
+# Note: GCC doesn't generates LIB files, as it uses its own archive files. To maintain compatibility
+#       between compilers, it must generate a LIB file. To do so, 'pexports' and 'dlltool' tools can be used,
+#       the first one to generate definition file (DEF), and the second one to generate a LIB file.
+if(${is_gcc} AND WIN32)
+    set(target_dir "$<TARGET_FILE_DIR:mjmem>")
+    add_custom_command(TARGET mjmem POST_BUILD
+        COMMAND pexports ${target_dir}/mjmem.dll > ${target_dir}/mjmem.def
+        COMMAND dlltool -d ${target_dir}/mjmem.def -l ${target_dir}/mjmem.lib
+    )
+    unset(target_dir)
+endif()
 
 # Note: RC files are used only on Windows and are compiled with rc.exe (MSVC), windres.exe (GCC),
 #       or llvm-windres.exe (Clang). Therefore, they are included only when compiling for Windows.
@@ -119,4 +142,8 @@ if(MJMEM_INSTALL_LIBRARY)
         NAMESPACE mjx::
     )
     install(FILES ${MJMEM_INC_FILES} DESTINATION "inc/mjmem")
+    if(${is_gcc} AND WIN32)
+        # copy manually generated mjmem.lib to the installation directory
+        install(FILES "$<TARGET_FILE_DIR:mjmem>/mjmem.lib" DESTINATION "bin/$<CONFIG>")
+    endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,8 +31,9 @@ set(MJMEM_SRC_FILES
 set(MJMEM_IMPL_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/allocation_tracking.hpp"    
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/bitops.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/dllmain.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/global_allocator.hpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/main.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/rwlock.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/tinywin.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/impl/utils.hpp"
 )
@@ -40,16 +41,66 @@ set(MJMEM_RES_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/res/mjmem.rc"
 )
 
+# Note: These definitions are the core macros for all MJX modules. Since the MJMEM module
+#       is the base for all modules, the macros are defined here. However, if this changes
+#       in the future, move the definitions to the module which becomes the base for all modules.
+set(MJX_BASE_DEFS)
+
+# detect the platform and set the corresponding macro, terminate if the platform is not recognized
+if(WIN32)
+    list(APPEND MJX_BASE_DEFS _MJX_WINDOWS=1)
+elseif(UNIX)
+    list(APPEND MJX_BASE_DEFS _MJX_LINUX=1)
+else()
+    # unsupported platform, report an error and terminate
+    message(FATAL_ERROR "Unsupported platform detected.")
+endif()
+
+# detect the compiler and set the corresponding macro, terminate if the compiler is not recognized 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    list(APPEND MJX_BASE_DEFS _MJX_CLANG=1)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    list(APPEND MJX_BASE_DEFS _MJX_GCC=1)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    list(APPEND MJX_BASE_DEFS _MJX_MSVC=1)
+else()
+    # unrecognized compiler, report an error and terminate
+    message(FATAL_ERROR "Detected unregonized compiler: ${CMAKE_CXX_COMPILER_ID}")
+endif()
+
+# detect the architecture and set the corresponding macro (never fails)
+if(${MJX_PLATFORM_ARCH} STREQUAL "x64")
+    list(APPEND MJX_BASE_DEFS _MJX_X64=1)
+elseif(${MJX_PLATFORM_ARCH} STREQUAL "x86")
+    list(APPEND MJX_BASE_DEFS _MJX_X86=1)
+endif()
+
+# detect the byte order and set the corresponding macro, terminate if unable to detect the byte order
+if(CMAKE_CXX_BYTE_ORDER STREQUAL "LITTLE_ENDIAN")
+    list(APPEND MJX_BASE_DEFS _MJX_LITTLE_ENDIAN=1)
+elseif(CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+    list(APPEND MJX_BASE_DEFS _MJX_BIG_ENDIAN=1)
+else()
+    # failed to detect the byte order, report an error and terminate
+    message(FATAL_ERROR "Byte order could not be detected.")
+endif()
+
 # organize source files into directories for better readability
 source_group("src" FILES ${MJMEM_INC_FILES} ${MJMEM_SRC_FILES})
 source_group("src/impl" FILES ${MJMEM_IMPL_FILES})
 source_group("res" FILES ${MJMEM_RES_FILES})
 
 # add the MJMEM shared library and adjust its properties
-add_library(mjmem SHARED ${MJMEM_INC_FILES} ${MJMEM_SRC_FILES} ${MJMEM_IMPL_FILES} ${MJMEM_RES_FILES})
-target_compile_definitions(mjmem PRIVATE _MJMEM_BUILD=1)
+add_library(mjmem SHARED ${MJMEM_INC_FILES} ${MJMEM_SRC_FILES} ${MJMEM_IMPL_FILES})
+target_compile_definitions(mjmem PRIVATE _MJMEM_BUILD=1 PUBLIC ${MJX_BASE_DEFS})
 target_compile_features(mjmem PRIVATE cxx_std_20)
-target_include_directories(mjmem PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(mjmem PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Note: RC files are used only on Windows and are compiled with rc.exe (MSVC), windres.exe (GCC),
+#       or llvm-windres.exe (Clang). Therefore, they are included only when compiling for Windows.
+if(WIN32)
+    target_sources(mjmem PRIVATE ${MJMEM_RES_FILES})
+endif()
 
 if(MJMEM_INSTALL_LIBRARY)
     if(NOT DEFINED CMAKE_INSTALL_PREFIX OR CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/src/mjmem/allocator.cpp
+++ b/src/mjmem/allocator.cpp
@@ -5,7 +5,6 @@
 
 #include <mjmem/allocator.hpp>
 #include <mjmem/impl/global_allocator.hpp>
-#include <mjmem/impl/utils.hpp>
 
 namespace mjx {
     allocator::allocator() noexcept {}

--- a/src/mjmem/allocator.hpp
+++ b/src/mjmem/allocator.hpp
@@ -10,7 +10,7 @@
 #include <mjmem/api.hpp>
 
 namespace mjx {
-    class __declspec(novtable) _MJMEM_API allocator { // base class for all allocators
+    class _MJX_NOVTABLE _MJMEM_API allocator { // base class for all allocators
     public:
         using value_type      = void;
         using size_type       = size_t;

--- a/src/mjmem/api.hpp
+++ b/src/mjmem/api.hpp
@@ -7,9 +7,23 @@
 #ifndef _MJMEM_API_HPP_
 #define _MJMEM_API_HPP_
 
+// Note: The MJMEM module serves as the foundation for other modules. Therefore, macros are placed
+//       in the <mjmem/api.hpp> header. This approach enables sharing macros across multiple modules
+//       without concerns about missing definitions.
+#if defined(_MJX_MSVC) || (defined(_MJX_CLANG) && defined(_MJX_WINDOWS))
+#define _MJX_NOVTABLE __declspec(novtable)
+#else // ^^^ __declspec(novtable) available ^^^ / vvv __declspec(novtable) not available vvv
+#define _MJX_NOVTABLE
+#endif // defined(_MJX_MSVC) || (defined(_MJX_CLANG) && defined(_MJX_WINDOWS))
+
+#ifdef _MJX_WINDOWS
+// Windows libraries (DLLs) require an additional attribute
 #ifdef _MJMEM_BUILD
 #define _MJMEM_API __declspec(dllexport)
 #else // ^^^ _MJMEM_BUILD ^^^ / vvv !_MJMEM_BUILD vvv
 #define _MJMEM_API __declspec(dllimport)
 #endif // _MJMEM_BUILD
+#else // ^^^ _MJX_WINDOWS ^^^ / vvv _MJX_LINUX vvv
+#define _MJMEM_API
+#endif // _MJX_WINDOWS
 #endif // _MJMEM_API_HPP_

--- a/src/mjmem/api.hpp
+++ b/src/mjmem/api.hpp
@@ -10,11 +10,11 @@
 // Note: The MJMEM module serves as the foundation for other modules. Therefore, macros are placed
 //       in the <mjmem/api.hpp> header. This approach enables sharing macros across multiple modules
 //       without concerns about missing definitions.
-#if defined(_MJX_MSVC) || (defined(_MJX_CLANG) && defined(_MJX_WINDOWS))
+#ifdef _MJX_MSVC
 #define _MJX_NOVTABLE __declspec(novtable)
-#else // ^^^ __declspec(novtable) available ^^^ / vvv __declspec(novtable) not available vvv
+#else // ^^^ _MJX_MSVC ^^^ / vvv !_MJX_MSVC vvv
 #define _MJX_NOVTABLE
-#endif // defined(_MJX_MSVC) || (defined(_MJX_CLANG) && defined(_MJX_WINDOWS))
+#endif // _MJX_MSVC
 
 #ifdef _MJX_WINDOWS
 // Windows libraries (DLLs) require an additional attribute

--- a/src/mjmem/impl/bitops.hpp
+++ b/src/mjmem/impl/bitops.hpp
@@ -6,10 +6,10 @@
 #pragma once
 #ifndef _MJMEM_IMPL_BITOPS_HPP_
 #define _MJMEM_IMPL_BITOPS_HPP_
+#include <algorithm>
 #include <bit>
 #include <climits>
 #include <cstdint>
-#include <utility>
 
 namespace mjx {
     namespace mjmem_impl {

--- a/src/mjmem/impl/dllmain.cpp
+++ b/src/mjmem/impl/dllmain.cpp
@@ -1,18 +1,19 @@
-// main.cpp
+// dllmain.cpp
 
 // Copyright (c) Mateusz Jandura. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#ifdef _MJX_WINDOWS
 #include <mjmem/impl/tinywin.hpp>
 
+// Note: Unlike Linux shared objects (SOs), Windows dynamic-link libraries (DLLs) require
+//       the definition of an entry point (DllMain), even if it does nothing.
+
 int __stdcall DllMain(HMODULE _Module, unsigned long _Reason, void*) {
-#if defined(_M_X64) || defined(_M_IX86)
     if (_Reason == DLL_PROCESS_ATTACH) {
         ::DisableThreadLibraryCalls(_Module);
     }
 
     return 1;
-#else // ^^^ x64 or x86 ^^^ / vvv not supported architecture vvv
-    return 0;
-#endif // defined(_M_X64) || defined(_M_IX86)
 }
+#endif // _MJX_WINDOWS

--- a/src/mjmem/impl/rwlock.hpp
+++ b/src/mjmem/impl/rwlock.hpp
@@ -1,0 +1,108 @@
+// rwlock.hpp
+
+// Copyright (c) Mateusz Jandura. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#ifndef _MJMEM_IMPL_RWLOCK_HPP_
+#define _MJMEM_IMPL_RWLOCK_HPP_
+#include <mjmem/impl/utils.hpp>
+#ifdef _MJX_WINDOWS
+#include <mjmem/impl/tinywin.hpp>
+#else // ^^^ _MJX_WINDOWS ^^^ / vvv _MJX_LINUX vvv
+#include <pthread.h>
+#endif // _MJX_WINDOWS
+
+namespace mjx {
+    namespace mjmem_impl {
+        class _Rw_lock { // reader-writer lock
+        public:
+            _Rw_lock(const _Rw_lock&)            = delete;
+            _Rw_lock& operator=(const _Rw_lock&) = delete;
+
+#ifdef _MJX_WINDOWS
+            _Rw_lock() noexcept : _Myhandle{0} {}
+
+            ~_Rw_lock() noexcept {}
+
+            void _Acquire_read_lock() noexcept {
+                ::AcquireSRWLockShared(&_Myhandle);
+            }
+
+            void _Acquire_write_lock() noexcept {
+                ::AcquireSRWLockExclusive(&_Myhandle);
+            }
+
+            void _Release_read_lock() noexcept {
+                ::ReleaseSRWLockShared(&_Myhandle);
+            }
+
+            void _Release_write_lock() noexcept {
+                _Analysis_assume_lock_acquired_(_Myhandle);
+                ::ReleaseSRWLockExclusive(&_Myhandle);
+            }
+#else // ^^^ _MJX_WINDOWS ^^^ / vvv _MJX_LINUX vvv
+            _Rw_lock() noexcept : _Myhandle{0} {
+                _INTERNAL_ASSERT(::pthread_rwlock_init(&_Myhandle, nullptr) == 0, "failed to initialize R/W Lock");
+            }
+
+            ~_Rw_lock() noexcept {
+                _INTERNAL_ASSERT(::pthread_rwlock_destroy(&_Myhandle) == 0, "failed to destroy R/W Lock");
+            }
+
+            void _Acquire_read_lock() noexcept {
+                _INTERNAL_ASSERT(::pthread_rwlock_rdlock(&_Myhandle) == 0, "failed to acquire read lock");
+            }
+
+            void _Acquire_write_lock() noexcept {
+                _INTERNAL_ASSERT(::pthread_rwlock_wrlock(&_Myhandle) == 0, "failed to acquire write lock");
+            }
+
+            void _Release_read_lock() noexcept {
+                _INTERNAL_ASSERT(::pthread_rwlock_unlock(&_Myhandle) == 0, "failed to release read lock");
+            }
+
+            void _Release_write_lock() noexcept {
+                _INTERNAL_ASSERT(::pthread_rwlock_unlock(&_Myhandle) == 0, "failed to release write lock");
+            }
+#endif // _MJX_WINDOWS
+
+        private:
+#ifdef _MJX_WINDOWS
+            SRWLOCK _Myhandle;
+#else // ^^^ _MJX_WINDOWS ^^^ / vvv _MJX_LINUX vvv
+            pthread_rwlock_t _Myhandle;
+#endif // _MJX_WINDOWS
+        };
+
+        class _Read_lock_guard { // RAII class for read lock acquisition
+        public:
+            _Read_lock_guard(_Rw_lock& _Lock) noexcept : _Mylock(_Lock) {
+                _Mylock._Acquire_read_lock();
+            }
+
+            ~_Read_lock_guard() noexcept {
+                _Mylock._Release_read_lock();
+            }
+
+        private:
+            _Rw_lock& _Mylock;
+        };
+
+        class _Write_lock_guard { // RAII class for write lock acquisition
+        public:
+            _Write_lock_guard(_Rw_lock& _Lock) noexcept : _Mylock(_Lock) {
+                _Mylock._Acquire_write_lock();
+            }
+
+            ~_Write_lock_guard() noexcept {
+                _Mylock._Release_write_lock();
+            }
+
+        private:
+            _Rw_lock& _Mylock;
+        };
+    } // namespace mjmem_impl
+} // namespace mjx
+
+#endif // _MJMEM_IMPL_RWLOCK_HPP_

--- a/src/mjmem/impl/tinywin.hpp
+++ b/src/mjmem/impl/tinywin.hpp
@@ -7,7 +7,9 @@
 #ifndef _MJMEM_IMPL_TINYWIN_HPP_
 #define _MJMEM_IMPL_TINYWIN_HPP_
 
+#ifdef _MJX_WINDOWS
 #define WIN32_LEAN_AND_MEAN
 #define NOSERVICE
 #include <Windows.h>
+#endif // _MJX_WINDOWS
 #endif // _MJMEM_IMPL_TINYWIN_HPP_

--- a/src/mjmem/pool_allocator.cpp
+++ b/src/mjmem/pool_allocator.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) Mateusz Jandura. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <cstdlib>
 #include <mjmem/exception.hpp>
 #include <mjmem/impl/allocation_tracking.hpp>
@@ -10,7 +11,6 @@
 #include <mjmem/impl/utils.hpp>
 #include <mjmem/object_allocator.hpp>
 #include <mjmem/pool_allocator.hpp>
-#include <utility>
 
 namespace mjx {
     pool_allocator::pool_allocator(pool_resource& _Resource, const size_type _Max_block_size)

--- a/src/mjmem/pool_resource.cpp
+++ b/src/mjmem/pool_resource.cpp
@@ -30,7 +30,7 @@ namespace mjx {
     }
 
     pool_resource& pool_resource::operator=(const pool_resource& _Other) {
-        if (this != ::std::addressof(_Other)) {
+        if (this != &_Other) {
             destroy();
             _Copy_resource(_Other._Mydata, _Other._Mysize);
         }
@@ -39,7 +39,7 @@ namespace mjx {
     }
 
     pool_resource& pool_resource::operator=(pool_resource&& _Other) noexcept {
-        if (this != ::std::addressof(_Other)) {
+        if (this != &_Other) {
             destroy();
             _Move_resource(_Other._Mydata, _Other._Mysize);
         }

--- a/src/mjmem/smart_pointer.hpp
+++ b/src/mjmem/smart_pointer.hpp
@@ -37,7 +37,7 @@ namespace mjx {
 
         optimized_pair& operator=(const optimized_pair& _Other) noexcept(
             ::std::is_nothrow_copy_assignable_v<_Ty1> && ::std::is_nothrow_copy_assignable_v<_Ty2>) {
-            if (this != ::std::addressof(_Other)) {
+            if (this != &_Other) {
                 _Myval                    = _Other._Myval;
                 static_cast<_Ty2&>(*this) = static_cast<const _Ty2&>(_Other);
             }
@@ -47,7 +47,7 @@ namespace mjx {
 
         optimized_pair& operator=(optimized_pair&& _Other) noexcept(
             ::std::is_nothrow_move_assignable_v<_Ty1> && ::std::is_nothrow_move_assignable_v<_Ty2>) {
-            if (this != ::std::addressof(_Other)) {
+            if (this != &_Other) {
                 _Myval                    = ::std::move(_Other);
                 static_cast<_Ty2&>(*this) = static_cast<_Ty2&&>(_Other);
             }
@@ -105,7 +105,7 @@ namespace mjx {
 
         optimized_pair& operator=(const optimized_pair& _Other) noexcept(
             ::std::is_nothrow_copy_assignable_v<_Ty1> && ::std::is_nothrow_copy_assignable_v<_Ty2>) {
-            if (this != ::std::addressof(_Other)) {
+            if (this != &_Other) {
                 _Myval1 = _Other._Myval1;
                 _Myval2 = _Other._Myval2;
             }
@@ -115,7 +115,7 @@ namespace mjx {
 
         optimized_pair& operator=(optimized_pair&& _Other) noexcept(
             ::std::is_nothrow_move_assignable_v<_Ty1> && ::std::is_nothrow_move_assignable_v<_Ty2>) {
-            if (this != ::std::addressof(_Other)) {
+            if (this != &_Other) {
                 _Myval1 = ::std::move(_Other._Myval1);
                 _Myval2 = ::std::move(_Other._Myval2);
             }

--- a/src/mjmem/smart_pointer.hpp
+++ b/src/mjmem/smart_pointer.hpp
@@ -7,6 +7,7 @@
 #ifndef _MJMEM_SMART_POINTER_HPP_
 #define _MJMEM_SMART_POINTER_HPP_
 #include <atomic>
+#include <cstddef>
 #include <mjmem/exception.hpp>
 #include <mjmem/object_allocator.hpp>
 #include <type_traits>
@@ -169,7 +170,7 @@ namespace mjx {
 
         unique_smart_ptr() noexcept : _Myptr(nullptr) {}
 
-        unique_smart_ptr(nullptr_t) noexcept : _Myptr(nullptr) {}
+        unique_smart_ptr(::std::nullptr_t) noexcept : _Myptr(nullptr) {}
 
         explicit unique_smart_ptr(pointer _Ptr) noexcept : _Myptr(_Ptr) {}
 
@@ -187,7 +188,7 @@ namespace mjx {
             return *this;
         }
 
-        unique_smart_ptr& operator=(nullptr_t) noexcept {
+        unique_smart_ptr& operator=(::std::nullptr_t) noexcept {
             reset();
             return *this;
         }
@@ -239,7 +240,7 @@ namespace mjx {
     }
 
     template <class _Ty>
-    inline bool operator==(const unique_smart_ptr<_Ty>& _Left, nullptr_t) noexcept {
+    inline bool operator==(const unique_smart_ptr<_Ty>& _Left, ::std::nullptr_t) noexcept {
         return !_Left;
     }
 
@@ -261,7 +262,7 @@ namespace mjx {
 
         unique_smart_array() noexcept : _Myptr(nullptr), _Mysize(0) {}
 
-        unique_smart_array(nullptr_t) noexcept : _Myptr(nullptr), _Mysize(0) {}
+        unique_smart_array(::std::nullptr_t) noexcept : _Myptr(nullptr), _Mysize(0) {}
 
         unique_smart_array(pointer _Ptr, const size_t _Size) noexcept : _Myptr(_Ptr), _Mysize(_Size) {}
 
@@ -285,7 +286,7 @@ namespace mjx {
             return *this;
         }
 
-        unique_smart_array& operator=(nullptr_t) noexcept {
+        unique_smart_array& operator=(::std::nullptr_t) noexcept {
             reset();
             return *this;
         }
@@ -329,7 +330,7 @@ namespace mjx {
             _Mysize = _New_size;
         }
 
-        void reset(nullptr_t = nullptr) noexcept {
+        void reset(::std::nullptr_t = nullptr) noexcept {
             if (_Myptr) {
                 ::mjx::delete_object_array(_Myptr, _Mysize);
                 _Myptr  = nullptr;
@@ -353,7 +354,7 @@ namespace mjx {
     }
 
     template <class _Ty>
-    inline bool operator==(const unique_smart_array<_Ty>& _Left, nullptr_t) noexcept {
+    inline bool operator==(const unique_smart_array<_Ty>& _Left, ::std::nullptr_t) noexcept {
         return !_Left;
     }
 
@@ -397,7 +398,7 @@ namespace mjx {
 
         smart_ptr() noexcept : _Myptr(nullptr), _Myctr(nullptr) {}
 
-        smart_ptr(nullptr_t) noexcept : _Myptr(nullptr), _Myctr(nullptr) {}
+        smart_ptr(::std::nullptr_t) noexcept : _Myptr(nullptr), _Myctr(nullptr) {}
 
         explicit smart_ptr(pointer _Ptr)
             : _Myptr(_Ptr), _Myctr(::mjx::create_object<reference_counter>(1)) {}
@@ -495,7 +496,7 @@ namespace mjx {
     }
 
     template <class _Ty>
-    inline bool operator==(const smart_ptr<_Ty>& _Left, nullptr_t) noexcept {
+    inline bool operator==(const smart_ptr<_Ty>& _Left, ::std::nullptr_t) noexcept {
         return !_Left;
     }
 
@@ -512,7 +513,7 @@ namespace mjx {
 
         smart_array() noexcept : _Myptr(nullptr), _Mysize(0), _Myctr(nullptr) {}
 
-        smart_array(nullptr_t) noexcept : _Myptr(nullptr), _Mysize(0), _Myctr(nullptr) {}
+        smart_array(::std::nullptr_t) noexcept : _Myptr(nullptr), _Mysize(0), _Myctr(nullptr) {}
 
         smart_array(pointer _Ptr, const size_t _Size)
             : _Myptr(_Ptr), _Mysize(_Size), _Myctr(::mjx::create_object<reference_counter>(1)) {}
@@ -623,7 +624,7 @@ namespace mjx {
     }
 
     template <class _Ty>
-    inline bool operator==(const smart_array<_Ty>& _Left, nullptr_t) noexcept {
+    inline bool operator==(const smart_array<_Ty>& _Left, ::std::nullptr_t) noexcept {
         return !_Left;
     }
 

--- a/src/mjmem/synchronized_allocator.cpp
+++ b/src/mjmem/synchronized_allocator.cpp
@@ -5,7 +5,8 @@
 
 #include <mjmem/impl/rwlock.hpp>
 #include <mjmem/synchronized_allocator.hpp>
-#include <type_traits>
+#include <new>
+#include <utility>
 
 namespace mjx {
     synchronized_allocator::synchronized_allocator(allocator& _Al) noexcept

--- a/src/mjmem/synchronized_allocator.cpp
+++ b/src/mjmem/synchronized_allocator.cpp
@@ -3,34 +3,40 @@
 // Copyright (c) Mateusz Jandura. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <mjmem/impl/utils.hpp>
+#include <mjmem/impl/rwlock.hpp>
 #include <mjmem/synchronized_allocator.hpp>
 #include <type_traits>
 
 namespace mjx {
     synchronized_allocator::synchronized_allocator(allocator& _Al) noexcept
-        : _Mywrapped(_Al), _Mylock{0} {}
+        : _Mywrapped(_Al), _Mylock{0} {
+        // construct an instance of _Rw_lock in the storage allocated by _Mylock
+        ::new (static_cast<void*>(_Mylock)) mjmem_impl::_Rw_lock;
+    }
 
-    synchronized_allocator::~synchronized_allocator() noexcept {}
+    synchronized_allocator::~synchronized_allocator() noexcept {
+        // explicitly call _Rw_lock's destructor to clean up the lock object
+        reinterpret_cast<mjmem_impl::_Rw_lock&>(_Mylock).~_Rw_lock();
+    }
 
     synchronized_allocator::pointer synchronized_allocator::allocate(const size_type _Count) {
-        mjmem_impl::_Lock_guard<false> _Guard(&_Mylock);
+        mjmem_impl::_Write_lock_guard _Guard(reinterpret_cast<mjmem_impl::_Rw_lock&>(_Mylock));
         return _Mywrapped.allocate(_Count);
     }
 
     synchronized_allocator::pointer
         synchronized_allocator::allocate_aligned(const size_type _Count, const size_type _Align) {
-        mjmem_impl::_Lock_guard<false> _Guard(&_Mylock);
+        mjmem_impl::_Write_lock_guard _Guard(reinterpret_cast<mjmem_impl::_Rw_lock&>(_Mylock));
         return _Mywrapped.allocate_aligned(_Count, _Align);
     }
 
     void synchronized_allocator::deallocate(pointer _Ptr, const size_type _Count) noexcept {
-        mjmem_impl::_Lock_guard<false> _Guard(&_Mylock);
+        mjmem_impl::_Write_lock_guard _Guard(reinterpret_cast<mjmem_impl::_Rw_lock&>(_Mylock));
         _Mywrapped.deallocate(_Ptr, _Count);
     }
 
     synchronized_allocator::size_type synchronized_allocator::max_size() const noexcept {
-        mjmem_impl::_Lock_guard<true> _Guard(&_Mylock);
+        mjmem_impl::_Read_lock_guard _Guard(reinterpret_cast<mjmem_impl::_Rw_lock&>(_Mylock));
         return _Mywrapped.max_size();
     }
 
@@ -42,7 +48,7 @@ namespace mjx {
             return false;
         }
 
-        mjmem_impl::_Lock_guard<true> _Guard(&_Mylock);
+        mjmem_impl::_Read_lock_guard _Guard(reinterpret_cast<mjmem_impl::_Rw_lock&>(_Mylock));
         return _Mywrapped.is_equal(_Other_ptr->_Mywrapped);
     }
 } // namespace mjx

--- a/src/mjmem/synchronized_allocator.hpp
+++ b/src/mjmem/synchronized_allocator.hpp
@@ -55,7 +55,7 @@ namespace mjx {
 #endif // _MJX_WINDOWS
 
         allocator& _Mywrapped; // wrapped allocator
-        mutable alignas(_Lock_align) unsigned char _Mylock[_Lock_size];
+        alignas(_Lock_align) mutable unsigned char _Mylock[_Lock_size];
     };
 } // namespace mjx
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,9 +32,13 @@ function(add_isolated_test test_name test_path)
     copy_files_required_for_test(${test_name})
 endfunction()
 
+# Note: The 'bitops' and 'block_allocator' tests are currently blocked until endianness
+#       support is added to the library. These tests rely on direct bit manipulation,
+#       which is not supported in the current Linux implementation.
+
 add_isolated_test(test_allocators_compatibility "src/allocators_compatibility/test.cpp")
-add_isolated_test(test_bitops "src/bitops/test.cpp")
-add_isolated_test(test_block_allocator "src/block_allocator/test.cpp")
+# add_isolated_test(test_bitops "src/bitops/test.cpp")
+# add_isolated_test(test_block_allocator "src/block_allocator/test.cpp")
 add_isolated_test(test_dynamic_allocator "src/dynamic_allocator/test.cpp")
 add_isolated_test(test_global_allocator "src/global_allocator/test.cpp")
 add_isolated_test(test_pool_allocator "src/pool_allocator/test.cpp")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ add_subdirectory(google-test "${CMAKE_CURRENT_BINARY_DIR}/google-test" EXCLUDE_F
 function(copy_files_required_for_test test_name)
     # copy all required files to the output directory of the specified test
     add_custom_command(TARGET ${test_name} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "$<TARGET_FILE:mjmem>"
         "$<TARGET_FILE_DIR:${test_name}>"
     )
@@ -32,13 +32,9 @@ function(add_isolated_test test_name test_path)
     copy_files_required_for_test(${test_name})
 endfunction()
 
-# Note: The 'bitops' and 'block_allocator' tests are currently blocked until endianness
-#       support is added to the library. These tests rely on direct bit manipulation,
-#       which is not supported in the current Linux implementation.
-
 add_isolated_test(test_allocators_compatibility "src/allocators_compatibility/test.cpp")
-# add_isolated_test(test_bitops "src/bitops/test.cpp")
-# add_isolated_test(test_block_allocator "src/block_allocator/test.cpp")
+add_isolated_test(test_bitops "src/bitops/test.cpp")
+add_isolated_test(test_block_allocator "src/block_allocator/test.cpp")
 add_isolated_test(test_dynamic_allocator "src/dynamic_allocator/test.cpp")
 add_isolated_test(test_global_allocator "src/global_allocator/test.cpp")
 add_isolated_test(test_pool_allocator "src/pool_allocator/test.cpp")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,15 +10,6 @@ project(mjmem_tests LANGUAGES CXX)
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory(google-test "${CMAKE_CURRENT_BINARY_DIR}/google-test" EXCLUDE_FROM_ALL)
 
-function(copy_files_required_for_test test_name)
-    # copy all required files to the output directory of the specified test
-    add_custom_command(TARGET ${test_name} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "$<TARGET_FILE:mjmem>"
-        "$<TARGET_FILE_DIR:${test_name}>"
-    )
-endfunction()
-
 function(add_isolated_test test_name test_path)
     # create an executable for the specified test, linking against necessary libraries
     add_executable(${test_name} ${test_path})
@@ -29,7 +20,6 @@ function(add_isolated_test test_name test_path)
     )
     target_link_libraries(${test_name} PRIVATE gtest gtest_main mjmem)
     add_test(NAME ${test_name} COMMAND ${test_name})
-    copy_files_required_for_test(${test_name})
 endfunction()
 
 add_isolated_test(test_allocators_compatibility "src/allocators_compatibility/test.cpp")
@@ -46,3 +36,28 @@ add_isolated_test(test_synchronized_allocator "src/synchronized_allocator/test.c
 add_isolated_test(test_unique_smart_array "src/unique_smart_array/test.cpp")
 add_isolated_test(test_unique_smart_ptr "src/unique_smart_ptr/test.cpp")
 add_isolated_test(test_version_encoding "src/version_encoding/test.cpp")
+
+# use a custom target to combine all targets into a single one,
+# this allows only one post-build call instead of per-test copying
+add_custom_target(mjmem_and_tests ALL DEPENDS
+    mjmem
+    test_allocators_compatibility
+    test_bitops
+    test_block_allocator
+    test_dynamic_allocator
+    test_global_allocator
+    test_pool_allocator
+    test_pool_resource
+    test_reference_counter
+    test_smart_array
+    test_smart_ptr
+    test_synchronized_allocator
+    test_unique_smart_array
+    test_unique_smart_ptr
+    test_version_encoding
+)
+add_custom_command(TARGET mjmem_and_tests POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "$<TARGET_FILE:mjmem>"
+    "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>" # copy to the tests' output directory
+)

--- a/tests/src/bitops/test.cpp
+++ b/tests/src/bitops/test.cpp
@@ -7,11 +7,14 @@
 #include <gtest/gtest.h>
 #include <mjmem/impl/bitops.hpp>
 
+ // the tests assume the platform is little-endian
+
 namespace mjx {
     using namespace mjmem_impl;
     
     constexpr size_t _Not_found = _Base_word_traits::_Not_found;
 
+#ifdef _MJX_LITTLE_ENDIAN
     TEST(bitops, count_trailing_zeros) {
         EXPECT_EQ(_Count_trailing_zeros<uint8_t>(0b11111111), 0);
         EXPECT_EQ(_Count_trailing_zeros<uint8_t>(0b00000010), 1);
@@ -62,4 +65,5 @@ namespace mjx {
         test_find_contiguous_zero_bits({0b10101010, 0b11111111, 0b00000000, 0b11111100}, 32, 10, 16);
         test_find_contiguous_zero_bits({0b11111111, 0b11111111, 0b11111111, 0b00011111}, 29, 3, _Not_found);
     }
+#endif // _MJX_LITTLE_ENDIAN
 } // namespace mjx

--- a/tests/src/block_allocator/test.cpp
+++ b/tests/src/block_allocator/test.cpp
@@ -11,7 +11,10 @@
 #include <mjmem/pool_resource.hpp>
 #include <mjmem/synchronized_allocator.hpp>
 
+// the tests assume the platform is little-endian
+
 namespace mjx {
+#ifdef _MJX_LITTLE_ENDIAN
     TEST(block_allocator, allocate) {
         pool_resource _Res(8);
         block_allocator _Al(_Res, 2);
@@ -84,4 +87,5 @@ namespace mjx {
         EXPECT_NE(_Block_al, _Pool_al);
         EXPECT_NE(_Block_al, _Sync_al);
     }
+#endif // _MJX_LITTLE_ENDIAN
 } // namespace mjx

--- a/tests/src/smart_array/test.cpp
+++ b/tests/src/smart_array/test.cpp
@@ -99,8 +99,13 @@ namespace mjx {
     TEST(smart_array, swap) {
         smart_array<char> _Arr0 = ::mjx::make_smart_array<char>(16);
         smart_array<char> _Arr1 = ::mjx::make_smart_array<char>(16);
+#if defined(_MJX_MSVC) || (defined(_MJX_CLANG) && defined(_MJX_WINDOWS))
+        ::strcpy_s(_Arr0.get(), _Arr0.size(), "_Arr0");
+        ::strcpy_s(_Arr1.get(), _Arr1.size(), "_Arr1");
+#else // ^^^ MSVC or Clang with MSVC toolchain ^^^ / vvv GCC vvv
         ::strcpy(_Arr0.get(), "_Arr0");
         ::strcpy(_Arr1.get(), "_Arr1");
+#endif // defined(_MJX_MSVC) || (defined(_MJX_CLANG) && defined(_MJX_WINDOWS))
         _Arr0.swap(_Arr1);
         EXPECT_STREQ(_Arr0.get(), "_Arr1");
         EXPECT_STREQ(_Arr1.get(), "_Arr0");

--- a/tests/src/unique_smart_array/test.cpp
+++ b/tests/src/unique_smart_array/test.cpp
@@ -64,8 +64,13 @@ namespace mjx {
     TEST(unique_smart_array, swap) {
         unique_smart_array<char> _Arr0 = ::mjx::make_unique_smart_array<char>(16);
         unique_smart_array<char> _Arr1 = ::mjx::make_unique_smart_array<char>(16);
+#if defined(_MJX_MSVC) || (defined(_MJX_CLANG) && defined(_MJX_WINDOWS))
+        ::strcpy_s(_Arr0.get(), _Arr0.size(), "_Arr0");
+        ::strcpy_s(_Arr1.get(), _Arr1.size(), "_Arr1");
+#else // ^^^ MSVC or Clang with MSVC toolchain ^^^ / vvv GCC vvv
         ::strcpy(_Arr0.get(), "_Arr0");
         ::strcpy(_Arr1.get(), "_Arr1");
+#endif // defined(_MJX_MSVC) || (defined(_MJX_CLANG) && defined(_MJX_WINDOWS))
         _Arr0.swap(_Arr1);
         EXPECT_STREQ(_Arr0.get(), "_Arr1");
         EXPECT_STREQ(_Arr1.get(), "_Arr0");


### PR DESCRIPTION
Resolves #63

Due to endianness incompatibility, the `bitops` and `block_allocator` benchmarks and tests are temporarily disabled.