### PR TITLE
Implement endianness detection and conversion

### DIFF
--- a/benchmarks/src/bitops/benchmark.cpp
+++ b/benchmarks/src/bitops/benchmark.cpp
@@ -6,8 +6,6 @@
 #include <benchmark/benchmark.h>
 #include <mjmem/impl/bitops.hpp>
 
-// the benchmarks assume the platform is little-endian
-
 namespace mjx {
     using namespace mjmem_impl;
 
@@ -1054,7 +1052,6 @@ void set_benchmark_properties(auto* const _Benchmark) {
     _Benchmark->DenseRange(1, 10)->Unit(::benchmark::TimeUnit::kNanosecond);
 }
 
-#ifdef _MJX_LITTLE_ENDIAN
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<64>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<128>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<256>)->Apply(set_benchmark_properties);
@@ -1063,6 +1060,5 @@ BENCHMARK(::mjx::bm_find_contiguous_zero_bits<1024>)->Apply(set_benchmark_proper
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<2048>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<4096>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_find_contiguous_zero_bits<8192>)->Apply(set_benchmark_properties);
-#endif // _MJX_LITTLE_ENDIAN
 
 BENCHMARK_MAIN();

--- a/benchmarks/src/block_allocator/benchmark.cpp
+++ b/benchmarks/src/block_allocator/benchmark.cpp
@@ -7,8 +7,6 @@
 #include <mjmem/block_allocator.hpp>
 #include <mjmem/pool_resource.hpp>
 
-// the benchmarks assume the platform is little-endian
-
 namespace mjx {
     inline constexpr size_t _Block_size = 16;
 
@@ -39,7 +37,6 @@ void set_benchmark_properties(auto* const _Benchmark) {
     _Benchmark->DenseRange(1, 10)->Unit(::benchmark::TimeUnit::kNanosecond);
 }
 
-#ifdef _MJX_LITTLE_ENDIAN
 BENCHMARK(::mjx::bm_allocate_block_allocator<128>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_allocate_block_allocator<256>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_allocate_block_allocator<512>)->Apply(set_benchmark_properties);
@@ -47,6 +44,5 @@ BENCHMARK(::mjx::bm_allocate_block_allocator<1024>)->Apply(set_benchmark_propert
 BENCHMARK(::mjx::bm_allocate_block_allocator<2048>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_allocate_block_allocator<4096>)->Apply(set_benchmark_properties);
 BENCHMARK(::mjx::bm_allocate_block_allocator<8192>)->Apply(set_benchmark_properties);
-#endif // _MJX_LITTLE_ENDIAN
 
 BENCHMARK_MAIN();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(MJMEM_INC_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/api.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/block_allocator.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/dynamic_allocator.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/endian.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/exception.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/object_allocator.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjmem/pool_allocator.hpp"
@@ -89,6 +90,26 @@ elseif(CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
 else()
     # failed to detect the byte order, report an error and terminate
     message(FATAL_ERROR "Byte order could not be detected.")
+endif()
+
+# detect support for 128-bit integers and set the corresponding macro (definitely not supported on MSVC)
+if(${is_clang} OR ${is_gcc})
+    # use check_cxx_source_compiles() to detect whether a program that uses 128-bit integers will compile
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles([=[
+        using _Int128_t  = __int128;
+        using _Uint128_t = unsigned __int128;
+        static_assert(sizeof(_Int128_t) == 16, "128-bit integer size mismatch");
+        static_assert(sizeof(_Uint128_t) == 16, "128-bit integer size mismatch");
+
+        int main() {
+            return 0;
+        }
+    ]=] int128_supported)
+    if(${int128_supported})
+        # 128-bit integers are supported, append the corresponding macro
+        list(APPEND MJX_BASE_DEFS _MJX_INT128_SUPPORTED=1)
+    endif()
 endif()
 
 # organize source files into directories for better readability

--- a/src/mjmem/endian.hpp
+++ b/src/mjmem/endian.hpp
@@ -8,7 +8,6 @@
 #define _MJMEM_ENDIAN_HPP_
 #include <mjmem/version.hpp>
 #if _MJMEM_VERSION_SUPPORTED(2, 1, 0)
-#include <concepts>
 #include <cstdint>
 #include <type_traits>
 #ifdef _MJX_MSVC

--- a/src/mjmem/endian.hpp
+++ b/src/mjmem/endian.hpp
@@ -90,6 +90,9 @@ namespace mjx {
 #endif // defined(_MJX_CLANG) || defined(_MJX_GCC)
         }
 #endif // _MJX_INT128_SUPPORTED
+
+        template <class... _Types>
+        inline constexpr bool _Always_false = false;
     } // namespace mjmem_impl
 
     template <integral _Ty>
@@ -110,7 +113,7 @@ namespace mjx {
         }
 #endif // _MJX_INT128_SUPPORTED
         else {
-            static_assert(false, "unexpected integer size");
+            static_assert(mjmem_impl::_Always_false<_Ty>, "unexpected integer size");
         }
     }
 

--- a/src/mjmem/endian.hpp
+++ b/src/mjmem/endian.hpp
@@ -1,0 +1,154 @@
+// endian.hpp
+
+// Copyright (c) Mateusz Jandura. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#ifndef _MJMEM_ENDIAN_HPP_
+#define _MJMEM_ENDIAN_HPP_
+#include <concepts>
+#include <cstdint>
+#include <type_traits>
+#ifdef _MJX_MSVC
+#include <cstdlib>
+#endif // _MJX_MSVC
+
+namespace mjx {
+#ifdef _MJX_INT128_SUPPORTED
+    using int128_t  = __int128;
+    using uint128_t = unsigned __int128;
+#endif // _MJX_INT128_SUPPORTED
+
+    template <class _Ty>
+    concept integral = ::std::disjunction_v<::std::is_integral<_Ty>
+#ifdef _MJX_INT128_SUPPORTED
+        , ::std::is_same<_Ty, int128_t>, ::std::is_same<_Ty, uint128_t>
+#endif // _MJX_INT128_SUPPORTED
+    >;
+
+    enum class endian : unsigned char {
+        little = 0,
+        big    = 1,
+#ifdef _MJX_LITTLE_ENDIAN
+        native = little
+#else // ^^^ _MJX_LITTLE_ENDIAN ^^^ / vvv _MJX_BIG_ENDIAN vvv
+        native = big
+#endif // _MJX_LITTLE_ENDIAN
+    };
+
+    // Note: The functions below should be placed in an internal header as they are
+    //       part of the implementation details. However, to maintain byteswap() constexpr,
+    //       these functions must be implemented in a public header and should not be exported.
+    namespace mjmem_impl {
+        constexpr uint16_t _Bswap16(const uint16_t _Value) noexcept {
+#if defined(_MJX_CLANG) || defined(_MJX_GCC)
+            return __builtin_bswap16(_Value);
+#else // ^^^ Clang or GCC ^^^ / vvv MSVC vvv
+            if (!::std::is_constant_evaluated()) {
+                return ::_byteswap_ushort(_Value);
+            } else {
+                return (_Value >> 8) | (_Value << 8);
+            }
+#endif // defined(_MJX_CLANG) || defined(_MJX_GCC)
+        }
+
+        constexpr uint32_t _Bswap32(const uint32_t _Value) noexcept {
+#if defined(_MJX_CLANG) || defined(_MJX_GCC)
+            return __builtin_bswap32(_Value);
+#else // ^^^ Clang or GCC ^^^ / vvv MSVC vvv
+            if (!::std::is_constant_evaluated()) {
+                return ::_byteswap_ulong(_Value);
+            } else {
+                return (_Value >> 24) | ((_Value & 0x00FF'0000) >> 8)
+                    | ((_Value & 0x0000'FF00) << 8) | (_Value << 24);
+            }
+#endif // defined(_MJX_CLANG) || defined(_MJX_GCC)
+        }
+
+        constexpr uint64_t _Bswap64(const uint64_t _Value) noexcept {
+#if defined(_MJX_CLANG) || defined(_MJX_GCC)
+            return __builtin_bswap64(_Value);
+#else // ^^^ Clang or GCC ^^^ / vvv MSVC vvv
+            if (!::std::is_constant_evaluated()) {
+                return ::_byteswap_uint64(_Value);
+            } else {
+                return (_Value >> 56) | ((_Value & 0x00FF'0000'0000'0000) >> 40)
+                    | ((_Value & 0x0000'FF00'0000'0000) >> 24) | ((_Value & 0x0000'00FF'0000'0000) >> 8)
+                    | ((_Value & 0x0000'0000'FF00'0000) << 8) | ((_Value & 0x0000'0000'00FF'0000) << 24)
+                    | ((_Value & 0x0000'0000'0000'FF00) << 40) | (_Value << 56);
+            }
+#endif // defined(_MJX_CLANG) || defined(_MJX_GCC)
+        }
+
+#ifdef _MJX_INT128_SUPPORTED
+        constexpr uint128_t _Bswap128(const uint128_t _Value) noexcept {
+#ifdef _MJX_GCC
+            return __builtin_bswap128(_Value);
+#else // ^^^ GCC ^^^ / vvv Clang or MSVC vvv
+            return (static_cast<uint128_t>(
+                _Bswap64(_Value & 0xFFFF'FFFF'FFFF'FFFF)) << 64) | _Bswap64(_Value >> 64);
+#endif // defined(_MJX_CLANG) || defined(_MJX_GCC)
+        }
+#endif // _MJX_INT128_SUPPORTED
+    } // namespace mjmem_impl
+
+    template <integral _Ty>
+    constexpr _Ty swap_endian(const _Ty _Value) noexcept {
+        // reverse the bytes of the given integer
+        if constexpr (sizeof(_Ty) == 1) {
+            return _Value;
+        } else if constexpr (sizeof(_Ty) == 2) {
+            return static_cast<_Ty>(mjmem_impl::_Bswap16(static_cast<uint16_t>(_Value)));
+        } else if constexpr (sizeof(_Ty) == 4) {
+            return static_cast<_Ty>(mjmem_impl::_Bswap32(static_cast<uint32_t>(_Value)));
+        } else if constexpr (sizeof(_Ty) == 8) {
+            return static_cast<_Ty>(mjmem_impl::_Bswap64(static_cast<uint64_t>(_Value)));
+        }
+#ifdef _MJX_INT128_SUPPORTED
+        else if constexpr (sizeof(_Ty) == 16) {
+            return static_cast<_Ty>(mjmem_impl::_Bswap128(static_cast<uint128_t>(_Value)));
+        }
+#endif // _MJX_INT128_SUPPORTED
+        else {
+            static_assert(false, "unexpected integer size");
+        }
+    }
+
+    template <integral _Ty>
+    constexpr _Ty to_little_endian(const _Ty _Value) noexcept {
+#ifdef _MJX_LITTLE_ENDIAN
+        return _Value;
+#else // ^^^ _MJX_LITTLE_ENDIAN ^^^ / vvv _MJX_BIG_ENDIAN vvv
+        return ::mjx::swap_endian(_Value);
+#endif // _MJX_LITTLE_ENDIAN
+    }
+
+    template <integral _Ty>
+    constexpr _Ty to_big_endian(const _Ty _Value) noexcept {
+#ifdef _MJX_BIG_ENDIAN
+        return _Value;
+#else // ^^^ _MJX_BIG_ENDIAN ^^^ / vvv _MJX_LITTLE_ENDIAN vvv
+        return ::mjx::swap_endian(_Value);
+#endif // _MJX_BIG_ENDIAN
+    }
+
+    template <integral _Ty>
+    constexpr _Ty from_little_endian(const _Ty _Value) noexcept {
+#ifdef _MJX_LITTLE_ENDIAN
+        return _Value;
+#else // ^^^ _MJX_LITTLE_ENDIAN ^^^ / vvv _MJX_BIG_ENDIAN vvv
+        return ::mjx::swap_endian(_Value);
+#endif // _MJX_LITTLE_ENDIAN
+    }
+
+    template <integral _Ty>
+    constexpr _Ty from_big_endian(const _Ty _Value) noexcept {
+#ifdef _MJX_BIG_ENDIAN
+        return _Value;
+#else // ^^^ _MJX_BIG_ENDIAN ^^^ / vvv _MJX_LITTLE_ENDIAN vvv
+        return ::mjx::swap_endian(_Value);
+#endif // _MJX_BIG_ENDIAN
+    }
+} // namespace mjx
+
+#endif // _MJMEM_ENDIAN_HPP_

--- a/src/mjmem/endian.hpp
+++ b/src/mjmem/endian.hpp
@@ -6,6 +6,8 @@
 #pragma once
 #ifndef _MJMEM_ENDIAN_HPP_
 #define _MJMEM_ENDIAN_HPP_
+#include <mjmem/version.hpp>
+#if _MJMEM_VERSION_SUPPORTED(2, 1, 0)
 #include <concepts>
 #include <cstdint>
 #include <type_traits>
@@ -37,7 +39,7 @@ namespace mjx {
     };
 
     // Note: The functions below should be placed in an internal header as they are
-    //       part of the implementation details. However, to maintain byteswap() constexpr,
+    //       part of the implementation details. However, to maintain swap_endian() constexpr,
     //       these functions must be implemented in a public header and should not be exported.
     namespace mjmem_impl {
         constexpr uint16_t _Bswap16(const uint16_t _Value) noexcept {
@@ -91,7 +93,7 @@ namespace mjx {
         }
 #endif // _MJX_INT128_SUPPORTED
 
-        template <class... _Types>
+        template <class...>
         inline constexpr bool _Always_false = false;
     } // namespace mjmem_impl
 
@@ -154,4 +156,5 @@ namespace mjx {
     }
 } // namespace mjx
 
+#endif // _MJMEM_VERSION_SUPPORTED(2, 1, 0)
 #endif // _MJMEM_ENDIAN_HPP_

--- a/src/mjmem/endian.hpp
+++ b/src/mjmem/endian.hpp
@@ -88,7 +88,7 @@ namespace mjx {
 #else // ^^^ GCC ^^^ / vvv Clang or MSVC vvv
             return (static_cast<uint128_t>(
                 _Bswap64(_Value & 0xFFFF'FFFF'FFFF'FFFF)) << 64) | _Bswap64(_Value >> 64);
-#endif // defined(_MJX_CLANG) || defined(_MJX_GCC)
+#endif // _MJX_GCC
         }
 #endif // _MJX_INT128_SUPPORTED
 

--- a/src/mjmem/res/mjmem.rc
+++ b/src/mjmem/res/mjmem.rc
@@ -12,7 +12,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_NEUTRAL
 #pragma code_page(65001)
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION    2, 0, 0, 0
+FILEVERSION    2, 1, 0, 0
 PRODUCTVERSION 2, 0, 0, 0
 FILEFLAGSMASK  0x3FL
 #ifdef _DEBUG
@@ -30,7 +30,7 @@ BEGIN
         BEGIN
             VALUE "CompanyName",      "Mateusz Jandura"
             VALUE "FileDescription",  "MJX Memory Module (MJMEM)"
-            VALUE "FileVersion",      "2.0.0.0"
+            VALUE "FileVersion",      "2.1.0.0"
             VALUE "InternalName",     "mjmem.dll"
             VALUE "LegalCopyright",   "Copyright © Mateusz Jandura. All rights reserved."
             VALUE "OriginalFilename", "mjmem.dll"

--- a/src/mjmem/version.hpp
+++ b/src/mjmem/version.hpp
@@ -18,7 +18,7 @@
 
 // defines the latest MJMEM library version, synchronized with the version specified in 'res/mjmem.rc'
 #define _MJMEM_VERSION_MAJOR 2ULL
-#define _MJMEM_VERSION_MINOR 0ULL
+#define _MJMEM_VERSION_MINOR 1ULL
 #define _MJMEM_VERSION_PATCH 0ULL
 #define _MJMEM_VERSION       _MJX_ENCODE_VERSION(_MJMEM_VERSION_MAJOR, _MJMEM_VERSION_MINOR, _MJMEM_VERSION_PATCH)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_isolated_test(test_allocators_compatibility "src/allocators_compatibility/te
 add_isolated_test(test_bitops "src/bitops/test.cpp")
 add_isolated_test(test_block_allocator "src/block_allocator/test.cpp")
 add_isolated_test(test_dynamic_allocator "src/dynamic_allocator/test.cpp")
+add_isolated_test(test_endian "src/endian/test.cpp")
 add_isolated_test(test_global_allocator "src/global_allocator/test.cpp")
 add_isolated_test(test_pool_allocator "src/pool_allocator/test.cpp")
 add_isolated_test(test_pool_resource "src/pool_resource/test.cpp")
@@ -45,6 +46,7 @@ add_custom_target(mjmem_and_tests ALL DEPENDS
     test_bitops
     test_block_allocator
     test_dynamic_allocator
+    test_endian
     test_global_allocator
     test_pool_allocator
     test_pool_resource

--- a/tests/src/bitops/test.cpp
+++ b/tests/src/bitops/test.cpp
@@ -7,14 +7,11 @@
 #include <gtest/gtest.h>
 #include <mjmem/impl/bitops.hpp>
 
- // the tests assume the platform is little-endian
-
 namespace mjx {
     using namespace mjmem_impl;
     
     constexpr size_t _Not_found = _Base_word_traits::_Not_found;
 
-#ifdef _MJX_LITTLE_ENDIAN
     TEST(bitops, count_trailing_zeros) {
         EXPECT_EQ(_Count_trailing_zeros<uint8_t>(0b11111111), 0);
         EXPECT_EQ(_Count_trailing_zeros<uint8_t>(0b00000010), 1);
@@ -65,5 +62,4 @@ namespace mjx {
         test_find_contiguous_zero_bits({0b10101010, 0b11111111, 0b00000000, 0b11111100}, 32, 10, 16);
         test_find_contiguous_zero_bits({0b11111111, 0b11111111, 0b11111111, 0b00011111}, 29, 3, _Not_found);
     }
-#endif // _MJX_LITTLE_ENDIAN
 } // namespace mjx

--- a/tests/src/endian/test.cpp
+++ b/tests/src/endian/test.cpp
@@ -1,0 +1,94 @@
+// test.cpp
+
+// Copyright (c) Mateusz Jandura. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <mjmem/endian.hpp>
+
+#ifdef _MJX_INT128_SUPPORTED
+#define _MAKE_UINT128(_Low, _High) static_cast<uint128_t>(_Low | (static_cast<uint128_t>(_High) << 64))
+#endif // _MJX_INT128_SUPPORTED
+
+namespace mjx {
+    TEST(endian, swap_endian_16) {
+        EXPECT_EQ(::mjx::swap_endian(uint16_t{0x1A2B}), 0x2B1A);
+        EXPECT_EQ(::mjx::swap_endian(uint16_t{0x3C4D}), 0x4D3C);
+        EXPECT_EQ(::mjx::swap_endian(uint16_t{0x5E6F}), 0x6F5E);
+        EXPECT_EQ(::mjx::swap_endian(uint16_t{0x7F8A}), 0x8A7F);
+        EXPECT_EQ(::mjx::swap_endian(uint16_t{0x9BCD}), 0xCD9B);
+    }
+
+    TEST(endian, swap_endian_32) {
+        EXPECT_EQ(::mjx::swap_endian(uint32_t{0x1234'5678}), 0x7856'3412);
+        EXPECT_EQ(::mjx::swap_endian(uint32_t{0xA1B2'C3D4}), 0xD4C3'B2A1);
+        EXPECT_EQ(::mjx::swap_endian(uint32_t{0x89AB'CDEF}), 0xEFCD'AB89);
+        EXPECT_EQ(::mjx::swap_endian(uint32_t{0x0F1E'2D3C}), 0x3C2D'1E0F);
+        EXPECT_EQ(::mjx::swap_endian(uint32_t{0x5566'7788}), 0x8877'6655);
+    }
+
+    TEST(endian, swap_endian_64) {
+        EXPECT_EQ(::mjx::swap_endian(uint64_t{0x1234'5678'90AB'CDEF}), 0xEFCD'AB90'7856'3412);
+        EXPECT_EQ(::mjx::swap_endian(uint64_t{0xA1B2'C3D4'E5F6'0789}), 0x8907'F6E5'D4C3'B2A1);
+        EXPECT_EQ(::mjx::swap_endian(uint64_t{0x89AB'CDEF'0123'4567}), 0x6745'2301'EFCD'AB89);
+        EXPECT_EQ(::mjx::swap_endian(uint64_t{0x0F1E'2D3C'4B5A'6978}), 0x7869'5A4B'3C2D'1E0F);
+        EXPECT_EQ(::mjx::swap_endian(uint64_t{0x5566'7788'99AA'BBCC}), 0xCCBB'AA99'8877'6655);
+    }
+
+#ifdef _MJX_INT128_SUPPORTED
+    TEST(endian, swap_endian_128) {
+        EXPECT_EQ(::mjx::swap_endian(_MAKE_UINT128(0x1234'5678'9ABC'DEF0, 0x1234'5678'9ABC'DEF0)),
+            _MAKE_UINT128(0xF0DE'BC9A'7856'3412, 0xF0DE'BC9A'7856'3412));
+        EXPECT_EQ(::mjx::swap_endian(_MAKE_UINT128(0xA1B2'C3D4'E5F6'0789, 0xA1B2'C3D4'E5F6'0789)),
+            _MAKE_UINT128(0x8907'F6E5'D4C3'B2A1, 0x8907'F6E5'D4C3'B2A1));
+        EXPECT_EQ(::mjx::swap_endian(_MAKE_UINT128(0x89AB'CDEF'0123'4567, 0x89AB'CDEF'0123'4567)),
+            _MAKE_UINT128(0x6745'2301'EFCD'AB89, 0x6745'2301'EFCD'AB89));
+        EXPECT_EQ(::mjx::swap_endian(_MAKE_UINT128(0x0F1E'2D3C'4B5A'6978, 0x0F1E'2D3C'4B5A'6978)),
+            _MAKE_UINT128(0x7869'5A4B'3C2D'1E0F, 0x7869'5A4B'3C2D'1E0F));
+        EXPECT_EQ(::mjx::swap_endian(_MAKE_UINT128(0x5566'7788'99AA'BBCC, 0x5566'7788'99AA'BBCC)),
+            _MAKE_UINT128(0xCCBB'AA99'8877'6655, 0xCCBB'AA99'8877'6655));
+    }
+#endif // _MJX_INT128_SUPPORTED
+
+    template <integral _Ty>
+    void test_to_endian(const _Ty _Value) noexcept {
+        const _Ty _Swapped = ::mjx::swap_endian(_Value);
+#ifdef _MJX_LITTLE_ENDIAN
+        EXPECT_EQ(::mjx::to_little_endian(_Value), _Value);
+        EXPECT_EQ(::mjx::to_big_endian(_Value), _Swapped);
+#else // ^^^ _MJX_LITTLE_ENDIAN ^^^ / vvv _MJX_BIG_ENDIAN vvv
+        EXPECT_EQ(::mjx::to_little_endian(_Value), _Swapped);
+        EXPECT_EQ(::mjx::to_big_endian(_Value), _Value);
+#endif // _MJX_LITTLE_ENDIAN
+    }
+
+    template <integral _Ty>
+    void test_from_endian(const _Ty _Value) noexcept {
+        const _Ty _Swapped = ::mjx::swap_endian(_Value);
+#ifdef _MJX_LITTLE_ENDIAN
+        EXPECT_EQ(::mjx::from_little_endian(_Value), _Value);
+        EXPECT_EQ(::mjx::from_big_endian(_Value), _Swapped);
+#else // ^^^ _MJX_LITTLE_ENDIAN ^^^ / vvv _MJX_BIG_ENDIAN vvv
+        EXPECT_EQ(::mjx::from_little_endian(_Value), _Swapped);
+        EXPECT_EQ(::mjx::from_big_endian(_Value), _Value);
+#endif // _MJX_LITTLE_ENDIAN
+    }
+
+    TEST(endian, to_endian) {
+        test_to_endian(uint16_t{0x1A2B});
+        test_to_endian(uint32_t{0x1234'5678});
+        test_to_endian(uint64_t{0x1234'5678'9ABC'DEF0});
+#ifdef _MJX_INT128_SUPPORTED
+        test_to_endian(_MAKE_UINT128(0xBEEF'CAFE'1234'5678, 0x0FED'CBA9'8765'4321));
+#endif // _MJX_INT128_SUPPORTED
+    }
+
+    TEST(endian, from_endian) {
+        test_from_endian(uint16_t{0x3C4D});
+        test_from_endian(uint32_t{0x9ABC'DEF0});
+        test_from_endian(uint64_t{0x0F1E'2D3C'4B5A'6978});
+#ifdef _MJX_INT128_SUPPORTED
+        test_from_endian(_MAKE_UINT128(0x1234'5678'9ABC'DEF0, 0xA1B2'C3D4'E5F6'7890));
+#endif // _MJX_INT128_SUPPORTED
+    }
+} // namespace mjx


### PR DESCRIPTION
Resolves #65

This PR introduces support for 128-bit integers when available. It also enables benchmarks and tests for `bitops` and `block_allocator`.